### PR TITLE
Validation of XDI files

### DIFF
--- a/baddata/BadFiles.txt
+++ b/baddata/BadFiles.txt
@@ -31,8 +31,11 @@ bad_24.xdi   error msg      Y     Header 'Family.Key: Value' -- Family starts wi
 bad_25.xdi   file read(5)   Y     No extra version given
 bad_26.xdi   file read(6)   Y     No user comment
 bad_27.xdi   file read(6)   Y     Line of '////', but no user comment
-bad_28.xdi   error msg      Y     incorrectly format date-time
-bad_29.xdi   error msg      Y     date-time has invalid range (month > 12)
+bad_28.xdi   file read(1)   Y     incorrectly format date-time
+bad_29.xdi   file read(1)   Y     date-time has invalid range (month > 12)
+bad_30.xdi   file read(1)   Y     Invalid element.edge and element.symbol, test accumulation in XDI_required_metadata
+bad_31.xdi   file read(1)   Y     Invalid value for d-spacing, trigger error in XDI_required_metadata
+bad_32.xdi   file read(7)   Y     Missing recommended fields
 
 Notes:
   1. files read, return value > 0, indicating Warning  
@@ -41,3 +44,4 @@ Notes:
   4. keys are allowed to start with a number...
   5. extra version is left as empty string ''
   6. user comment is left as empty string ''
+  7. files read, XDI_recommended_metadata returns non-0

--- a/baddata/bad_30.xdi
+++ b/baddata/bad_30.xdi
@@ -1,0 +1,40 @@
+# XDI/1.0 GSE/1.0
+# Column.1: energy eV
+# Column.2: i0
+# Column.3: itrans
+# Column.4: mutrans
+# Element.edge: Bar
+# Element.symbol: Foo
+# Scan.edge_energy: 8980.0
+# Mono.name: Si 111
+# Mono.d_spacing: 3.13553
+# Beamline.name: 13ID
+# Beamline.collimation: none
+# Beamline.focusing: yes
+# Beamline.harmonic_rejection: rhodium-coated mirror
+# Facility.name: APS
+# Facility.energy: 7.00 GeV
+# Facility.xray_source: APS Undulator A
+# Scan.start_time: 2001-06-26T22:27:31
+# Detector.I0: 10cm  N2
+# Detector.I1: 10cm  N2
+# Sample.name: Cu
+# Sample.prep: Cu metal foil
+# GSE.EXTRA:  config 1
+# ///
+# Cu foil Room Temperature
+# measured at beamline 13-ID
+#----
+# energy i0 itrans mutrans
+  8779.0  149013.7  550643.089065  -1.3070486
+  8789.0  144864.7  531876.119084  -1.3006104
+  8799.0  132978.7  489591.10592  -1.3033816
+  8809.0  125444.7  463051.104096  -1.3059724
+  8819.0  121324.7  449969.103983  -1.3107085
+  8829.0  119447.7  444386.117562  -1.3138152
+  8839.0  119100.7  440176.091039  -1.3072055
+  8849.0  117707.7  440448.106567  -1.3195882
+  8859.0  117754.7  442302.10637  -1.3233895
+  8869.0  117428.7  441944.116528  -1.3253521
+  8879.0  117383.7  442810.120466  -1.327693
+  8889.0  117185.7  443658.11566  -1.3312944

--- a/baddata/bad_31.xdi
+++ b/baddata/bad_31.xdi
@@ -1,0 +1,40 @@
+# XDI/1.0 GSE/1.0
+# Column.1: energy eV
+# Column.2: i0
+# Column.3: itrans
+# Column.4: mutrans
+# Element.edge: K
+# Element.symbol: Cu
+# Scan.edge_energy: 8980.0
+# Mono.name: Si 111
+# Mono.d_spacing: three point one three five five three
+# Beamline.name: 13ID
+# Beamline.collimation: none
+# Beamline.focusing: yes
+# Beamline.harmonic_rejection: rhodium-coated mirror
+# Facility.name: APS
+# Facility.energy: 7.00 GeV
+# Facility.xray_source: APS Undulator A
+# Scan.start_time: 2001-06-26T22:27:31
+# Detector.I0: 10cm  N2
+# Detector.I1: 10cm  N2
+# Sample.name: Cu
+# Sample.prep: Cu metal foil
+# GSE.EXTRA:  config 1
+# ///
+# Cu foil Room Temperature
+# measured at beamline 13-ID
+#----
+# energy i0 itrans mutrans
+  8779.0  149013.7  550643.089065  -1.3070486
+  8789.0  144864.7  531876.119084  -1.3006104
+  8799.0  132978.7  489591.10592  -1.3033816
+  8809.0  125444.7  463051.104096  -1.3059724
+  8819.0  121324.7  449969.103983  -1.3107085
+  8829.0  119447.7  444386.117562  -1.3138152
+  8839.0  119100.7  440176.091039  -1.3072055
+  8849.0  117707.7  440448.106567  -1.3195882
+  8859.0  117754.7  442302.10637  -1.3233895
+  8869.0  117428.7  441944.116528  -1.3253521
+  8879.0  117383.7  442810.120466  -1.327693
+  8889.0  117185.7  443658.11566  -1.3312944

--- a/baddata/bad_32.xdi
+++ b/baddata/bad_32.xdi
@@ -1,0 +1,38 @@
+# XDI/1.0 GSE/1.0
+# Column.1: Energie eV
+# Column.2: i0
+# Column.3: itrans
+# Column.4: mutrans
+# Element.edge: K
+# Element.symbol: Cu
+# Scan.edge_energy: 8980.0
+# Mono.name: Si 111
+# Mono.d_spacing: 3.13553
+# Beamline.collimation: none
+# Beamline.focusing: yes
+# Beamline.harmonic_rejection: rhodium-coated mirror
+# Facility.energy: 7.00 GeV
+# Facility.xray_source: APS Undulator A
+# Scan.start_time: 2001-06-26T22:27:31
+# Detector.I0: 10cm  N2
+# Detector.I1: 10cm  N2
+# Sample.name: Cu
+# Sample.prep: Cu metal foil
+# GSE.EXTRA:  config 1
+# ///
+# Cu foil Room Temperature
+# measured at beamline 13-ID
+#----
+# energy i0 itrans mutrans
+  8779.0  149013.7  550643.089065  -1.3070486
+  8789.0  144864.7  531876.119084  -1.3006104
+  8799.0  132978.7  489591.10592  -1.3033816
+  8809.0  125444.7  463051.104096  -1.3059724
+  8819.0  121324.7  449969.103983  -1.3107085
+  8829.0  119447.7  444386.117562  -1.3138152
+  8839.0  119100.7  440176.091039  -1.3072055
+  8849.0  117707.7  440448.106567  -1.3195882
+  8859.0  117754.7  442302.10637  -1.3233895
+  8869.0  117428.7  441944.116528  -1.3253521
+  8879.0  117383.7  442810.120466  -1.327693
+  8889.0  117185.7  443658.11566  -1.3312944

--- a/c/LICENSE
+++ b/c/LICENSE
@@ -1,0 +1,20 @@
+The xdifile library and its consitutuent source code (xdifile.c,
+xdifile.h, strutil.f, strutils.h) are free and unencumbered software
+released into the public domain.
+
+Anyone is free to copy, modify, publish, use, compile, sell, or
+distribute this software, either in source code form or as a compiled
+binary, for any purpose, commercial or non-commercial, and by any
+means.
+
+In jurisdictions that recognize copyright laws, the author or authors
+of this software dedicate any and all copyright interest in the
+software to the public domain.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.

--- a/c/LICENSE.slre
+++ b/c/LICENSE.slre
@@ -1,0 +1,16 @@
+Copyright (c) 2004-2013 Sergey Lyubka <valenok@gmail.com>
+Copyright (c) 2013 Cesanta Software Limited
+All rights reserved
+
+This code is dual-licensed: you can redistribute it and/or modify
+it under the terms of the GNU General Public License version 2 as
+published by the Free Software Foundation. For the terms of this
+license, see <http://www.gnu.org/licenses/>.
+
+You are free to use this code under the terms of the GNU General
+Public License, but WITHOUT ANY WARRANTY; without even the implied
+warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+See the GNU General Public License for more details.
+
+Alternatively, you can license this code under a commercial
+license, as set out in <http://cesanta.com/>.

--- a/c/README.md
+++ b/c/README.md
@@ -134,7 +134,7 @@ translation of a table of error messages into another language.
 ### XDI_readfile error codes
 
  | code | message                                                      |
- |------|--------------------------------------------------------------|
+ | ---- | ------------------------------------------------------------ |
  |  -1  | not an XDI file, no XDI versioning information in first line |
  |  -2  | <word> -- invalid family name in metadata                    |
  |  -4  | <word> -- invalid keyword name in metadata                   |
@@ -147,7 +147,7 @@ Here `<word>` will be the the text that triggered the error.
 ### XDI_readfile warning codes
 
  |  code | message                                                      |
- |-------|--------------------------------------------------------------|
+ | ----- | ------------------------------------------------------------ |
  |    1  | no mono.d_spacing given with angle array                     |
  |    2  | no line of minus signs '#-----' separating header from data  |
  |    4  | contains unrecognized header lines                           |
@@ -168,7 +168,7 @@ bitwise.  That is, a return code of 7 means that all three required
 metadata fields were missing.
 
  | code | message                             |
- |------|-------------------------------------|
+ | ---- | ----------------------------------- |
  |  1   | Element.symbol missing or not valid |
  |  2   | Element.edge missing or not valid   |
  |  4   | Mono.d\_spacing missing             |
@@ -181,7 +181,7 @@ bitwise.  That is, a return code of 7 means that the first three
 recommendation metadata fields were missing.
 
  | code | message                                             |
- |------|-----------------------------------------------------|
+ | ---- | --------------------------------------------------- |
  |  1   | Missing recommended metadata field: Facility.name   |
  |  2   | Missing recommended metadata field: Facility.source |
  |  4   | Missing recommended metadata field: Beamline.name   |

--- a/c/README.md
+++ b/c/README.md
@@ -27,7 +27,7 @@ contents of the XDI file along with a few particularly important items
 | meta\_values    | array of char*     | array of values found among the metadata, indexed to nmetadata |
 | narrays         | long               | number of arrays in data table |
 | npts            | long               | number of rows in data table  |
-| array           | of array of double | the data table |
+| array           | 2D array of double | the data table |
 | narray\_labels  | long               | number of array labels |
 | array\_labels   | array of char*     | array of labels for arrays in the data table |
 | array\_units    | array of char*     | array of units for arrays in the data table |
@@ -147,7 +147,7 @@ Validation tests do not exist for all items in the metadata dictionary
     }
 ```
 
-### Examine arrays from the data table
+### Extract named arrays from the data table
 
 ```C
 	double *enarray, *muarray;
@@ -218,18 +218,18 @@ The return code from `XDI_required_metadata` can be interpreted
 bitwise.  That is, a return code of 7 means that all three required
 metadata fields were missing.
 
-| code | message                             |
-| ---: | ----------------------------------- |
-|  1   | Element.symbol missing or not valid |
-|  2   | Element.edge missing or not valid   |
-|  4   | Mono.d\_spacing missing             |
-|  8   | Mono.d\_spacing not valid           |
+| code | message                                |
+| ---: | -------------------------------------- |
+|  1   | Element.symbol missing or not valid    |
+|  2   | Element.edge missing or not valid      |
+|  4   | Mono.d\_spacing missing                |
+|  8   | Non-numeric value for Mono.d\_spacing  |
 
 ### XDI_recommended_metadata return codes
 
 The return code from `XDI_recommended_metadata` can be interpreted
 bitwise.  That is, a return code of 7 means that the first three
-recommendation metadata fields were missing.
+recommended metadata fields were missing.
 
 | code | message                                             |
 | ---: | --------------------------------------------------- |

--- a/c/README.md
+++ b/c/README.md
@@ -12,7 +12,7 @@ import and interpret XDI-formatted data.
 
 ## API
 
-### read an XDI file
+### Read an XDI file
 
 Read an XDI file, store it's content in an XDIFile struct, and return
 an integer return code.
@@ -25,9 +25,9 @@ an integer return code.
 	ret = XDI_readfile("mydata.xdi", xdifile);
 ```
 
-### interpret the XDI_readfile error code
+### Interpret the XDI_readfile error code
 
-Interpret the return code by printing teh corresponding error massage
+Interpret the return code by printing the corresponding error message
 to the screen:
 
 ```C
@@ -51,7 +51,7 @@ or warning message from the most recent action.  If an error code
 returns as non-zero, the content of `xdifile->error_message` will
 explain the meaning of the error code in English.
 
-### test for required metadata
+### Test for required metadata
 
 Test whether the **required** metadata was present in the XDI file.
 If `XDI_required_metadata` returns a non-zero value, the file is
@@ -59,15 +59,16 @@ If `XDI_required_metadata` returns a non-zero value, the file is
 
 ```C
 	j = XDI_required_metadata(xdifile);
-	if (j != 0) {
-		printf("\n# check for required metadata -- (requirement code %ld):\n%s\n", j, xdifile->error_message);
+	if (j != 0 ) {
+		printf("\n# check for required metadata -- (requirement code %ld):\n%s\n",
+			j, xdifile->error_message);
 	}
 ```
 
 Run `xdi_reader` agains `baddata/bad_30.xdi` for an example of a
 file which is non-compliant because of missing **required** metadata.
 
-### test for recommended metadata
+### Test for recommended metadata
 
 Test whether the **recommended** metadata was present in the XDI file.
 If `XDI_required_metadata` returns a non-zero value, the file is
@@ -76,8 +77,9 @@ highly useful to the interchange of the data contained in the file.
 
 ```C
 	j = XDI_recommended_metadata(xdifile);
-	if (j != ) {
-		printf("\n# check for recommended metadata -- (recommendation code %ld):\n%s\n", j, xdifile->error_message);
+	if (j != 0 ) {
+		printf("\n# check for recommended metadata -- (recommendation code %ld):\n%s\n",
+			j, xdifile->error_message);
 	}
 ```
 
@@ -131,14 +133,33 @@ translation of a table of error messages into another language.
 
 ### XDI_readfile error codes
 
-| code | message |
-|  -1  | |
-|  -2  | |
+ | code | message                                                      |
+ |------|--------------------------------------------------------------|
+ |  -1  | not an XDI file, no XDI versioning information in first line |
+ |  -2  | <word> -- invalid family name in metadata                    |
+ |  -4  | <word> -- invalid keyword name in metadata                   |
+ |  -8  | <word> -- not formatted as Family.Key: Value                 |
+ | -16  | number of columns changes in data table                      |
+ | -32  | non-numeric value in data table: <word>                      |
+
+Here `<word>` will be the the text that triggered the error.
 
 ### XDI_readfile warning codes
 
-|  1  | |
-|  2  | |
+ |  code | message                                                      |
+ |-------|--------------------------------------------------------------|
+ |    1  | no mono.d_spacing given with angle array                     |
+ |    2  | no line of minus signs '#-----' separating header from data  |
+ |    4  | contains unrecognized header lines                           |
+ |    8  | element.symbol missing or not valid                          |
+ |   16  | element.edge missing or not valid                            |
+ |   32  | element.reference not valid                                  |
+ |   64  | element.ref\_edge  not valid                                 |
+ |  128  | extension field used without versioning information          |
+ |  256  | Column.1 is not "energy" or "angle"                          |
+ |  512  | invalid timestamp: format should be ISO 8601 (YYYY-MM-DD HH:MM:SS) |
+ | 1024  | invalid timestamp: date out of valuid range                  |
+
 
 ### XDI_required_metadata return codes
 
@@ -146,9 +167,12 @@ The return code from `XDI_required_metadata` can be interpreted
 bitwise.  That is, a return code of 7 means that all three required
 metadata fields were missing.
 
-|  1  | |
-|  2  | |
-|  4  | |
+ | code | message                             |
+ |------|-------------------------------------|
+ |  1   | Element.symbol missing or not valid |
+ |  2   | Element.edge missing or not valid   |
+ |  4   | Mono.d\_spacing missing             |
+ |  4   | Mono.d\_spacing not valid           |
 
 ### XDI_recommended_metadata return codes
 
@@ -156,8 +180,11 @@ The return code from `XDI_recommended_metadata` can be interpreted
 bitwise.  That is, a return code of 7 means that the first three
 recommendation metadata fields were missing.
 
-|  1  | |
-|  2  | |
-|  4  | |
-|  8  | |
-| 16  | |
+ | code | message                                             |
+ |------|-----------------------------------------------------|
+ |  1   | Missing recommended metadata field: Facility.name   |
+ |  2   | Missing recommended metadata field: Facility.source |
+ |  4   | Missing recommended metadata field: Beamline.name   |
+ |  8   | Missing recommended metadata field: Scan.start_time |
+ | 16   | Missing recommended metadata field: Column.1        |
+

--- a/c/README.md
+++ b/c/README.md
@@ -3,12 +3,49 @@
 This is a C implementation of the XDI specification.  While the XDI
 specification is not difficult to implement correctly, we encourage
 people implementing XDI readers in other languages to base their
-implementation on `libxdifile`.  That way, the behaviour of XDI
+implementation on `libxdifile`.  That way, the behavior of XDI
 readers in different languages is guaranteed to be identical (or at
 least very similar).
 
 See `xdi_reader.c` for an example of a C program using `libxdifile` to
 import and interpret XDI-formatted data.
+
+`libxdifile` was written by Matt Newville and Bruce Ravel.
+
+## XDIFile struct
+
+This is the content of the XDIFile struct.  It will contain the entire
+contents of the XDI file along with a few particularly important items
+(d-spaing, element, and edge).
+
+| attribute       | type               | explanation |
+| --------------- | ------------------ | ----------- |
+| nmetadata       | long               | number of metadata fields |
+| narrays         | long               | number of arrays in data table |
+| npts            | long               | number of rows in data table  |
+| narray\_labels  | long               | number of array labels |
+| error\_lineno   | long               | the line number of a line returning an error |
+| dspacing        | double             | the Mono.d-spacing value              |
+| xdi\_libversion | char*              | the `libxdifile` version number |
+| xdi\_version    | char*              | the XDI file specification version number from the file |
+| extra\_version  | char*              | versioning information for extension fields |
+| filename        | char*              | the name of the XDI file |
+| element         | char*              | the 1, 2, or 3 letter symbol of the element |
+| edge            | char*              | the 1 or 2 letter symbol of the edge |
+| comments        | char*              | the user supplied comments from the XDI file |
+| error\_line     | char*              | the line returning an error  |
+| error\_message  | char*              | the error message |
+| array\_labels   | array of char*     | array of labels for arrays in the data table |
+| array\_units    | array of char*     | array of units for arrays in the data table |
+| meta\_families  | array of char*     | array of family names found among the metadata, indexed to nmetadata |
+| meta\_keywords  | array of char*     | array of keyword names found among the metadata, indexed to nmetadata |
+| meta\_values    | array of char*     | array of values found among the metadata, indexed to nmetadata |
+| array           | of array of double | the data table |
+| nouter          | long               | |
+| outer\_label    | array char*        | |
+| outer\_array    | array of double    | |
+| outer\_breakpts | array of long      | |
+
 
 ## API
 
@@ -65,7 +102,7 @@ If `XDI_required_metadata` returns a non-zero value, the file is
 	}
 ```
 
-Run `xdi_reader` agains `baddata/bad_30.xdi` for an example of a
+Run `xdi_reader` against `baddata/bad_30.xdi` for an example of a
 file which is non-compliant because of missing **required** metadata.
 
 ### Test for recommended metadata
@@ -83,7 +120,7 @@ highly useful to the interchange of the data contained in the file.
 	}
 ```
 
-Run `xdi_reader` agains `baddata/bad_32.xdi` for an example of a
+Run `xdi_reader` against `baddata/bad_32.xdi` for an example of a
 file which is missing **recommended** metadata.
 
 
@@ -125,6 +162,20 @@ table.  The return value is -1 if the array cannot be retrieved.
 
 The array names are held in the `Column.N` metadata fields.
 
+### Destroy and deallocate the XDIFile struct
+
+To deallocate the memory from the XDIFile struct, do this:
+
+```C
+	XDI_cleanup(xdifile, ret);
+```
+
+Here, the second argument is the return code from the call to
+XDI_readfile.  That is needed so that the cleanup method knows how
+much stuff needs to be freed.
+
+
+
 ## Error codes
 
 Here is a list of all error codes and their English explanation.  An
@@ -134,20 +185,20 @@ translation of a table of error messages into another language.
 ### XDI_readfile error codes
 
 | code | message                                                      |
-| ---- | ------------------------------------------------------------ |
+| ---: | ------------------------------------------------------------ |
 |  -1  | not an XDI file, no XDI versioning information in first line |
-|  -2  | `<word>` -- invalid family name in metadata                    |
-|  -4  | `<word>` -- invalid keyword name in metadata                   |
-|  -8  | `<word>` -- not formatted as Family.Key: Value                 |
+|  -2  | `<word>` -- invalid family name in metadata                  |
+|  -4  | `<word>` -- invalid keyword name in metadata                 |
+|  -8  | `<word>` -- not formatted as Family.Key: Value               |
 | -16  | number of columns changes in data table                      |
-| -32  | non-numeric value in data table: `<word>`                      |
+| -32  | non-numeric value in data table: `<word>`                    |
 
 Here `<word>` will be the the text that triggered the error.
 
 ### XDI_readfile warning codes
 
 |  code | message                                                      |
-| ----- | ------------------------------------------------------------ |
+| ----: | ------------------------------------------------------------ |
 |    1  | no mono.d_spacing given with angle array                     |
 |    2  | no line of minus signs '#-----' separating header from data  |
 |    4  | contains unrecognized header lines                           |
@@ -158,7 +209,7 @@ Here `<word>` will be the the text that triggered the error.
 |  128  | extension field used without versioning information          |
 |  256  | Column.1 is not "energy" or "angle"                          |
 |  512  | invalid timestamp: format should be ISO 8601 (YYYY-MM-DD HH:MM:SS) |
-| 1024  | invalid timestamp: date out of valuid range                  |
+| 1024  | invalid timestamp: date out of valid range                   |
 
 
 ### XDI_required_metadata return codes
@@ -168,7 +219,7 @@ bitwise.  That is, a return code of 7 means that all three required
 metadata fields were missing.
 
 | code | message                             |
-| ---- | ----------------------------------- |
+| ---: | ----------------------------------- |
 |  1   | Element.symbol missing or not valid |
 |  2   | Element.edge missing or not valid   |
 |  4   | Mono.d\_spacing missing             |
@@ -181,7 +232,7 @@ bitwise.  That is, a return code of 7 means that the first three
 recommendation metadata fields were missing.
 
 | code | message                                             |
-| ---- | --------------------------------------------------- |
+| ---: | --------------------------------------------------- |
 |  1   | Missing recommended metadata field: Facility.name   |
 |  2   | Missing recommended metadata field: Facility.source |
 |  4   | Missing recommended metadata field: Beamline.name   |

--- a/c/README.md
+++ b/c/README.md
@@ -20,27 +20,27 @@ contents of the XDI file along with a few particularly important items
 
 | attribute       | type               | explanation |
 | --------------- | ------------------ | ----------- |
-| nmetadata       | long               | number of metadata fields |
-| narrays         | long               | number of arrays in data table |
-| npts            | long               | number of rows in data table  |
-| narray\_labels  | long               | number of array labels |
-| error\_lineno   | long               | the line number of a line returning an error |
-| dspacing        | double             | the Mono.d-spacing value              |
-| xdi\_libversion | char*              | the `libxdifile` version number |
-| xdi\_version    | char*              | the XDI file specification version number from the file |
-| extra\_version  | char*              | versioning information for extension fields |
 | filename        | char*              | the name of the XDI file |
-| element         | char*              | the 1, 2, or 3 letter symbol of the element |
-| edge            | char*              | the 1 or 2 letter symbol of the edge |
-| comments        | char*              | the user supplied comments from the XDI file |
-| error\_line     | char*              | the line returning an error  |
-| error\_message  | char*              | the error message |
-| array\_labels   | array of char*     | array of labels for arrays in the data table |
-| array\_units    | array of char*     | array of units for arrays in the data table |
+| nmetadata       | long               | number of metadata fields |
 | meta\_families  | array of char*     | array of family names found among the metadata, indexed to nmetadata |
 | meta\_keywords  | array of char*     | array of keyword names found among the metadata, indexed to nmetadata |
 | meta\_values    | array of char*     | array of values found among the metadata, indexed to nmetadata |
+| narrays         | long               | number of arrays in data table |
+| npts            | long               | number of rows in data table  |
 | array           | of array of double | the data table |
+| narray\_labels  | long               | number of array labels |
+| array\_labels   | array of char*     | array of labels for arrays in the data table |
+| array\_units    | array of char*     | array of units for arrays in the data table |
+| comments        | char*              | the user supplied comments from the XDI file |
+| xdi\_libversion | char*              | the `libxdifile` version number |
+| xdi\_version    | char*              | the XDI file specification version number from the file |
+| extra\_version  | char*              | versioning information for extension fields |
+| dspacing        | double             | the Mono.d-spacing value              |
+| element         | char*              | the Element.symbol value, the 1, 2, or 3 letter symbol of the element |
+| edge            | char*              | the Element.edge value, the the 1 or 2 letter symbol of the edge |
+| error\_lineno   | long               | the line number of a line returning an error |
+| error\_line     | char*              | the line returning an error  |
+| error\_message  | char*              | the error message |
 | nouter          | long               | |
 | outer\_label    | array char*        | |
 | outer\_array    | array of double    | |

--- a/c/README.md
+++ b/c/README.md
@@ -136,29 +136,29 @@ translation of a table of error messages into another language.
 | code | message                                                      |
 | ---- | ------------------------------------------------------------ |
 |  -1  | not an XDI file, no XDI versioning information in first line |
-|  -2  | <word> -- invalid family name in metadata                    |
-|  -4  | <word> -- invalid keyword name in metadata                   |
-|  -8  | <word> -- not formatted as Family.Key: Value                 |
+|  -2  | `<word>` -- invalid family name in metadata                    |
+|  -4  | `<word>` -- invalid keyword name in metadata                   |
+|  -8  | `<word>` -- not formatted as Family.Key: Value                 |
 | -16  | number of columns changes in data table                      |
-| -32  | non-numeric value in data table: <word>                      |
+| -32  | non-numeric value in data table: `<word>`                      |
 
 Here `<word>` will be the the text that triggered the error.
 
 ### XDI_readfile warning codes
 
- |  code | message                                                      |
- | ----- | ------------------------------------------------------------ |
- |    1  | no mono.d_spacing given with angle array                     |
- |    2  | no line of minus signs '#-----' separating header from data  |
- |    4  | contains unrecognized header lines                           |
- |    8  | element.symbol missing or not valid                          |
- |   16  | element.edge missing or not valid                            |
- |   32  | element.reference not valid                                  |
- |   64  | element.ref\_edge  not valid                                 |
- |  128  | extension field used without versioning information          |
- |  256  | Column.1 is not "energy" or "angle"                          |
- |  512  | invalid timestamp: format should be ISO 8601 (YYYY-MM-DD HH:MM:SS) |
- | 1024  | invalid timestamp: date out of valuid range                  |
+|  code | message                                                      |
+| ----- | ------------------------------------------------------------ |
+|    1  | no mono.d_spacing given with angle array                     |
+|    2  | no line of minus signs '#-----' separating header from data  |
+|    4  | contains unrecognized header lines                           |
+|    8  | element.symbol missing or not valid                          |
+|   16  | element.edge missing or not valid                            |
+|   32  | element.reference not valid                                  |
+|   64  | element.ref\_edge  not valid                                 |
+|  128  | extension field used without versioning information          |
+|  256  | Column.1 is not "energy" or "angle"                          |
+|  512  | invalid timestamp: format should be ISO 8601 (YYYY-MM-DD HH:MM:SS) |
+| 1024  | invalid timestamp: date out of valuid range                  |
 
 
 ### XDI_required_metadata return codes
@@ -167,12 +167,12 @@ The return code from `XDI_required_metadata` can be interpreted
 bitwise.  That is, a return code of 7 means that all three required
 metadata fields were missing.
 
- | code | message                             |
- | ---- | ----------------------------------- |
- |  1   | Element.symbol missing or not valid |
- |  2   | Element.edge missing or not valid   |
- |  4   | Mono.d\_spacing missing             |
- |  4   | Mono.d\_spacing not valid           |
+| code | message                             |
+| ---- | ----------------------------------- |
+|  1   | Element.symbol missing or not valid |
+|  2   | Element.edge missing or not valid   |
+|  4   | Mono.d\_spacing missing             |
+|  8   | Mono.d\_spacing not valid           |
 
 ### XDI_recommended_metadata return codes
 
@@ -180,11 +180,11 @@ The return code from `XDI_recommended_metadata` can be interpreted
 bitwise.  That is, a return code of 7 means that the first three
 recommendation metadata fields were missing.
 
- | code | message                                             |
- | ---- | --------------------------------------------------- |
- |  1   | Missing recommended metadata field: Facility.name   |
- |  2   | Missing recommended metadata field: Facility.source |
- |  4   | Missing recommended metadata field: Beamline.name   |
- |  8   | Missing recommended metadata field: Scan.start_time |
- | 16   | Missing recommended metadata field: Column.1        |
+| code | message                                             |
+| ---- | --------------------------------------------------- |
+|  1   | Missing recommended metadata field: Facility.name   |
+|  2   | Missing recommended metadata field: Facility.source |
+|  4   | Missing recommended metadata field: Beamline.name   |
+|  8   | Missing recommended metadata field: Scan.start_time |
+| 16   | Missing recommended metadata field: Column.1        |
 

--- a/c/README.md
+++ b/c/README.md
@@ -73,6 +73,7 @@ to the screen:
 		printf("Error reading XDI file '%s':\n     %s\t(error code = %ld)\n",
 			argv[1], xdifile->error_message, ret);
 		XDI_cleanup(xdifile, ret);
+		free(xdifile);
 		return 1;
 	}
 
@@ -168,6 +169,7 @@ To deallocate the memory from the XDIFile struct, do this:
 
 ```C
 	XDI_cleanup(xdifile, ret);
+	free(xdifile);
 ```
 
 Here, the second argument is the return code from the call to

--- a/c/README.md
+++ b/c/README.md
@@ -1,0 +1,19 @@
+# libxdifile
+
+This is a C implementation of the XDI specification.  While the XDI
+specification is not difficult to implement correctly, we encourage
+people implementing XDI readers in other languages to base their
+implementation on `libxdifile`.  That way, the behaviour of XDI
+readers in different languages is guaranteed to be identical (or at
+least very similar).
+
+See `xdi_reader.c` for an example of a C program using `libxdifile` to
+import and interpret XDI-formatted data.
+
+## API
+
+```C
+	int ret;
+	xdifile = malloc(sizeof(XDIFile));
+	ret = XDI_readfile(argv[1], xdifile);
+```

--- a/c/README.md
+++ b/c/README.md
@@ -8,7 +8,9 @@ readers in different languages is guaranteed to be identical (or at
 least very similar).
 
 See `xdi_reader.c` for an example of a C program using `libxdifile` to
-import and interpret XDI-formatted data.
+import and interpret XDI-formatted data.  See the python and perl
+wrappers for examples of language specific implementations which use
+`libxdifile`.
 
 `libxdifile` was written by Matt Newville and Bruce Ravel.
 
@@ -16,7 +18,7 @@ import and interpret XDI-formatted data.
 
 This is the content of the XDIFile struct.  It will contain the entire
 contents of the XDI file along with a few particularly important items
-(d-spaing, element, and edge).
+(d-spacing, element, and edge).
 
 | attribute       | type               | explanation |
 | --------------- | ------------------ | ----------- |
@@ -100,7 +102,7 @@ All error messages are returned in English as the content of the
 `error_message` attribute of the `XDIFile` struct.  The
 `error_message` attribute always contains a description of the error
 condition of the most recently performed action.  The relation between
-the returned error/warning codes and teh error messages are tabulated
+the returned error/warning codes and the error messages are tabulated
 below.
 
 The value of separating most validation chores from the parsing of the

--- a/c/README.md
+++ b/c/README.md
@@ -12,8 +12,152 @@ import and interpret XDI-formatted data.
 
 ## API
 
+### read an XDI file
+
+Read an XDI file, store it's content in an XDIFile struct, and return
+an integer return code.
+
 ```C
+	XDIFile *xdifile;
 	int ret;
+
 	xdifile = malloc(sizeof(XDIFile));
-	ret = XDI_readfile(argv[1], xdifile);
+	ret = XDI_readfile("mydata.xdi", xdifile);
 ```
+
+### interpret the XDI_readfile error code
+
+Interpret the return code by printing teh corresponding error massage
+to the screen:
+
+```C
+	/* react to a terminal error */
+	if (ret < 0) {
+		printf("Error reading XDI file '%s':\n     %s\t(error code = %ld)\n",
+			argv[1], xdifile->error_message, ret);
+		XDI_cleanup(xdifile, ret);
+		return 1;
+	}
+
+	/* react to a warning */
+	if (ret > 0) {
+		printf("Warning reading XDI file '%s':\n     %s\t(warning code = %ld)\n\n",
+			argv[1], xdifile->error_message, ret);
+	}
+```
+
+The `xdifile->error_message` attribute will always contain the error
+or warning message from the most recent action.  If an error code
+returns as non-zero, the content of `xdifile->error_message` will
+explain the meaning of the error code in English.
+
+### test for required metadata
+
+Test whether the **required** metadata was present in the XDI file.
+If `XDI_required_metadata` returns a non-zero value, the file is
+**not compliant** with the XDI specification.
+
+```C
+	j = XDI_required_metadata(xdifile);
+	if (j != 0) {
+		printf("\n# check for required metadata -- (requirement code %ld):\n%s\n", j, xdifile->error_message);
+	}
+```
+
+Run `xdi_reader` agains `baddata/bad_30.xdi` for an example of a
+file which is non-compliant because of missing **required** metadata.
+
+### test for recommended metadata
+
+Test whether the **recommended** metadata was present in the XDI file.
+If `XDI_required_metadata` returns a non-zero value, the file is
+compliant with the XDI specification, but lacks information considered
+highly useful to the interchange of the data contained in the file.
+
+```C
+	j = XDI_recommended_metadata(xdifile);
+	if (j != ) {
+		printf("\n# check for recommended metadata -- (recommendation code %ld):\n%s\n", j, xdifile->error_message);
+	}
+```
+
+Run `xdi_reader` agains `baddata/bad_32.xdi` for an example of a
+file which is missing **recommended** metadata.
+
+
+### Examine and validate metadata
+
+This `for` loop iterates through each set of metadata family, keyword,
+and value found in the XDI file.  `XDI_validate_item` tests the value
+to see if it meets the recommendation of the specification.
+Validation tests do not exist for all items in the metadata dictionary
+-- `XDI_validate_item` will return 0 for 
+
+```C
+	for (i=0; i < xdifile->nmetadata; i++) {
+		printf(" %s / %s => %s\n",
+			xdifile->meta_families[i],
+			xdifile->meta_keywords[i],
+			xdifile->meta_values[i]);
+
+	    j = XDI_validate_item(xdifile, xdifile->meta_families[i], xdifile->meta_keywords[i], xdifile->meta_values[i]);
+		if (j!=0) {
+			printf("-- Warning for %s.%s: %s\t(warning code = %ld)\n\t%s\n",
+				xdifile->meta_families[i], xdifile->meta_keywords[i], xdifile->meta_values[i], j, xdifile->error_message);
+	    }
+    }
+```
+
+### Examine arrays from the data table
+
+```C
+	double *enarray, *muarray;
+	enarray = (double *)calloc(xdifile->npts, sizeof(double));
+	muarray = (double *)calloc(xdifile->npts, sizeof(double));
+    ret = XDI_get_array_name(xdifile, "energy",  enarray);
+    ret = XDI_get_array_name(xdifile, "mutrans", muarray);
+```
+
+The return value is 0 if an array by that name was found in the data
+table.  The return value is -1 if the array cannot be retrieved.
+
+The array names are held in the `Column.N` metadata fields.
+
+## Error codes
+
+Here is a list of all error codes and their English explanation.  An
+application using `libxdifile` can use these lists as the basis for
+translation of a table of error messages into another language.
+
+### XDI_readfile error codes
+
+| code | message |
+|  -1  | |
+|  -2  | |
+
+### XDI_readfile warning codes
+
+|  1  | |
+|  2  | |
+
+### XDI_required_metadata return codes
+
+The return code from `XDI_required_metadata` can be interpreted
+bitwise.  That is, a return code of 7 means that all three required
+metadata fields were missing.
+
+|  1  | |
+|  2  | |
+|  4  | |
+
+### XDI_recommended_metadata return codes
+
+The return code from `XDI_recommended_metadata` can be interpreted
+bitwise.  That is, a return code of 7 means that the first three
+recommendation metadata fields were missing.
+
+|  1  | |
+|  2  | |
+|  4  | |
+|  8  | |
+| 16  | |

--- a/c/README.md
+++ b/c/README.md
@@ -133,14 +133,14 @@ translation of a table of error messages into another language.
 
 ### XDI_readfile error codes
 
- | code | message                                                      |
- | ---- | ------------------------------------------------------------ |
- |  -1  | not an XDI file, no XDI versioning information in first line |
- |  -2  | <word> -- invalid family name in metadata                    |
- |  -4  | <word> -- invalid keyword name in metadata                   |
- |  -8  | <word> -- not formatted as Family.Key: Value                 |
- | -16  | number of columns changes in data table                      |
- | -32  | non-numeric value in data table: <word>                      |
+| code | message                                                      |
+| ---- | ------------------------------------------------------------ |
+|  -1  | not an XDI file, no XDI versioning information in first line |
+|  -2  | <word> -- invalid family name in metadata                    |
+|  -4  | <word> -- invalid keyword name in metadata                   |
+|  -8  | <word> -- not formatted as Family.Key: Value                 |
+| -16  | number of columns changes in data table                      |
+| -32  | non-numeric value in data table: <word>                      |
 
 Here `<word>` will be the the text that triggered the error.
 

--- a/c/slre.c
+++ b/c/slre.c
@@ -1,830 +1,433 @@
-// Copyright (c) 2004-2012 Sergey Lyubka <valenok@gmail.com>
-// All rights reserved
-//
-// Permission is hereby granted, free of charge, to any person obtaining a copy
-// of this software and associated documentation files (the "Software"), to deal
-// in the Software without restriction, including without limitation the rights
-// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-// copies of the Software, and to permit persons to whom the Software is
-// furnished to do so, subject to the following conditions:
-//
-// The above copyright notice and this permission notice shall be included in
-// all copies or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-// THE SOFTWARE.
+/*
+ * Copyright (c) 2004-2013 Sergey Lyubka <valenok@gmail.com>
+ * Copyright (c) 2013 Cesanta Software Limited
+ * All rights reserved
+ *
+ * This library is dual-licensed: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation. For the terms of this
+ * license, see <http://www.gnu.org/licenses/>.
+ *
+ * You are free to use this library under the terms of the GNU General
+ * Public License, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * Alternatively, you can license this library under a commercial
+ * license, as set out in <http://cesanta.com/products.html>.
+ */
 
 #include <stdio.h>
-#include <assert.h>
 #include <ctype.h>
-#include <stdarg.h>
-#include <stdlib.h>
 #include <string.h>
-#include <errno.h>
 
 #include "slre.h"
 
-// Compiled regular expression
-struct slre {
-  unsigned char code[256];
-  unsigned char data[256];
-  int code_size;
-  int data_size;
-  int num_caps;   // Number of bracket pairs
-  int anchored;   // Must match from string start
-  enum slre_option options;
-  const char *error_string;   // Error string
-};
+#define MAX_BRANCHES 100
+#define MAX_BRACKETS 100
+#define FAIL_IF(condition, error_code) if (condition) return (error_code)
 
-// Captured substring
-struct cap {
-  const char *ptr;  // Pointer to the substring
-  int len;          // Substring length
-};
-
-enum {
-  END, BRANCH, ANY, EXACT, ANYOF, ANYBUT, OPEN, CLOSE, BOL, EOL, STAR, PLUS,
-  STARQ, PLUSQ, QUEST, SPACE, NONSPACE, DIGIT
-};
-
-// Commands and operands are all unsigned char (1 byte long). All code offsets
-// are relative to current address, and positive (always point forward). Data
-// offsets are absolute. Commands with operands:
-//
-// BRANCH offset1 offset2
-//  Try to match the code block that follows the BRANCH instruction
-//  (code block ends with END). If no match, try to match code block that
-//  starts at offset1. If either of these match, jump to offset2.
-//
-// EXACT data_offset data_length
-//  Try to match exact string. String is recorded in data section from
-//  data_offset, and has length data_length.
-//
-// OPEN capture_number
-// CLOSE capture_number
-//  If the user have passed 'struct cap' array for captures, OPEN
-//  records the beginning of the matched substring (cap->ptr), CLOSE
-//  sets the length (cap->len) for respective capture_number.
-//
-// STAR code_offset
-// PLUS code_offset
-// QUEST code_offset
-//  *, +, ?, respectively. Try to gobble as much as possible from the
-//  matched buffer while code block that follows these instructions
-//  matches. When the longest possible string is matched,
-//  jump to code_offset
-//
-// STARQ, PLUSQ are non-greedy versions of STAR and PLUS.
-
-static const char *meta_characters = "|.^$*+?()[\\";
-static const char *error_no_match = "No match";
-
-static void set_jump_offset(struct slre *r, int pc, int offset) {
-  assert(offset < r->code_size);
-  if (r->code_size - offset > 0xff) {
-    r->error_string = "Jump offset is too big";
-  } else {
-    r->code[pc] = (unsigned char) (r->code_size - offset);
-  }
-}
-
-static void emit(struct slre *r, int code) {
-  if (r->code_size >= (int) (sizeof(r->code) / sizeof(r->code[0]))) {
-    r->error_string = "RE is too long (code overflow)";
-  } else {
-    r->code[r->code_size++] = (unsigned char) code;
-  }
-}
-
-static void store_char_in_data(struct slre *r, int ch) {
-  if (r->data_size >= (int) sizeof(r->data)) {
-    r->error_string = "RE is too long (data overflow)";
-  } else {
-    r->data[r->data_size++] = ch;
-  }
-}
-
-static void exact(struct slre *r, const char **re) {
-  int  old_data_size = r->data_size;
-
-  while (**re != '\0' && (strchr(meta_characters, **re)) == NULL) {
-    store_char_in_data(r, *(*re)++);
-  }
-
-  emit(r, EXACT);
-  emit(r, old_data_size);
-  emit(r, r->data_size - old_data_size);
-}
-
-static int get_escape_char(const char **re) {
-  int  res;
-
-  switch (*(*re)++) {
-    case 'n':  res = '\n';    break;
-    case 'r':  res = '\r';    break;
-    case 't':  res = '\t';    break;
-    case '0':  res = 0;    break;
-    case 'S':  res = NONSPACE << 8;  break;
-    case 's':  res = SPACE << 8;  break;
-    case 'd':  res = DIGIT << 8;  break;
-    default:  res = (*re)[-1];  break;
-  }
-
-  return res;
-}
-
-static void anyof(struct slre *r, const char **re) {
-  int  esc, old_data_size = r->data_size, op = ANYOF;
-
-  if (**re == '^') {
-    op = ANYBUT;
-    (*re)++;
-  }
-
-  while (**re != '\0')
-
-    switch (*(*re)++) {
-      case ']':
-        emit(r, op);
-        emit(r, old_data_size);
-        emit(r, r->data_size - old_data_size);
-        return;
-        // NOTREACHED
-        break;
-      case '\\':
-        esc = get_escape_char(re);
-        if ((esc & 0xff) == 0) {
-          store_char_in_data(r, 0);
-          store_char_in_data(r, esc >> 8);
-        } else {
-          store_char_in_data(r, esc);
-        }
-        break;
-      default:
-        store_char_in_data(r, (*re)[-1]);
-        break;
-    }
-
-  r->error_string = "No closing ']' bracket";
-}
-
-static void relocate(struct slre *r, int begin, int shift) {
-  emit(r, END);
-  memmove(r->code + begin + shift, r->code + begin, r->code_size - begin);
-  r->code_size += shift;
-}
-
-static void quantifier(struct slre *r, int prev, int op) {
-  if (r->code[prev] == EXACT && r->code[prev + 2] > 1) {
-    r->code[prev + 2]--;
-    emit(r, EXACT);
-    emit(r, r->code[prev + 1] + r->code[prev + 2]);
-    emit(r, 1);
-    prev = r->code_size - 3;
-  }
-  relocate(r, prev, 2);
-  r->code[prev] = op;
-  set_jump_offset(r, prev + 1, prev);
-}
-
-static void exact_one_char(struct slre *r, int ch) {
-  emit(r, EXACT);
-  emit(r, r->data_size);
-  emit(r, 1);
-  store_char_in_data(r, ch);
-}
-
-static void fixup_branch(struct slre *r, int fixup) {
-  if (fixup > 0) {
-    emit(r, END);
-    set_jump_offset(r, fixup, fixup - 2);
-  }
-}
-
-static void compile(struct slre *r, const char **re) {
-  int  op, esc, branch_start, last_op, fixup, cap_no, level;
-
-  fixup = 0;
-  level = r->num_caps;
-  branch_start = last_op = r->code_size;
-
-  for (;;)
-    switch (*(*re)++) {
-
-      case '\0':
-        (*re)--;
-        return;
-        // NOTREACHED
-        break;
-
-      case '^':
-        emit(r, BOL);
-        break;
-
-      case '$':
-        emit(r, EOL);
-        break;
-
-      case '.':
-        last_op = r->code_size;
-        emit(r, ANY);
-        break;
-
-      case '[':
-        last_op = r->code_size;
-        anyof(r, re);
-        break;
-
-      case '\\':
-        last_op = r->code_size;
-        esc = get_escape_char(re);
-        if (esc & 0xff00) {
-          emit(r, esc >> 8);
-        } else {
-          exact_one_char(r, esc);
-        }
-        break;
-
-      case '(':
-        last_op = r->code_size;
-        cap_no = ++r->num_caps;
-        emit(r, OPEN);
-        emit(r, cap_no);
-
-        compile(r, re);
-        if (*(*re)++ != ')') {
-          r->error_string = "No closing bracket";
-          return;
-        }
-
-        emit(r, CLOSE);
-        emit(r, cap_no);
-        break;
-
-      case ')':
-        (*re)--;
-        fixup_branch(r, fixup);
-        if (level == 0) {
-          r->error_string = "Unbalanced brackets";
-          return;
-        }
-        return;
-        // NOTREACHED
-        break;
-
-      case '+':
-      case '*':
-        op = (*re)[-1] == '*' ? STAR: PLUS;
-        if (**re == '?') {
-          (*re)++;
-          op = op == STAR ? STARQ : PLUSQ;
-        }
-        quantifier(r, last_op, op);
-        break;
-
-      case '?':
-        quantifier(r, last_op, QUEST);
-        break;
-
-      case '|':
-        fixup_branch(r, fixup);
-        relocate(r, branch_start, 3);
-        r->code[branch_start] = BRANCH;
-        set_jump_offset(r, branch_start + 1, branch_start);
-        fixup = branch_start + 2;
-        r->code[fixup] = 0xff;
-        break;
-
-      default:
-        (*re)--;
-        last_op = r->code_size;
-        exact(r, re);
-        break;
-    }
-}
-
-// Compile regular expression. If success, 1 is returned.
-// If error, 0 is returned and slre.error_string points to the error message.
-static const char *compile2(struct slre *r, const char *re) {
-  r->error_string = NULL;
-  r->code_size = r->data_size = r->num_caps = r->anchored = 0;
-
-  if (*re == '^') {
-    r->anchored++;
-  }
-
-  emit(r, OPEN);  // This will capture what matches full RE
-  emit(r, 0);
-
-  while (*re != '\0') {
-    compile(r, &re);
-  }
-
-  if (r->code[2] == BRANCH) {
-    fixup_branch(r, 4);
-  }
-
-  emit(r, CLOSE);
-  emit(r, 0);
-  emit(r, END);
-
-#if 0
-  static void dump(const struct slre *, FILE *);
-  dump(r, stdout);
+#ifndef ARRAY_SIZE
+#define ARRAY_SIZE(ar) (sizeof(ar) / sizeof((ar)[0]))
 #endif
 
-  return r->error_string;
+#ifdef SLRE_DEBUG
+#define DBG(x) printf x
+#else
+#define DBG(x)
+#endif
+
+struct bracket_pair {
+  const char *ptr;  /* Points to the first char after '(' in regex  */
+  int len;          /* Length of the text between '(' and ')'       */
+  int branches;     /* Index in the branches array for this pair    */
+  int num_branches; /* Number of '|' in this bracket pair           */
+};
+
+struct branch {
+  int bracket_index;    /* index for 'struct bracket_pair brackets' */
+                        /* array defined below                      */
+  const char *schlong;  /* points to the '|' character in the regex */
+};
+
+struct regex_info {
+  /*
+   * Describes all bracket pairs in the regular expression.
+   * First entry is always present, and grabs the whole regex.
+   */
+  struct bracket_pair brackets[MAX_BRACKETS];
+  int num_brackets;
+
+  /*
+   * Describes alternations ('|' operators) in the regular expression.
+   * Each branch falls into a specific branch pair.
+   */
+  struct branch branches[MAX_BRANCHES];
+  int num_branches;
+
+  /* Array of captures provided by the user */
+  struct slre_cap *caps;
+  int num_caps;
+
+  /* E.g. SLRE_IGNORE_CASE. See enum below */
+  int flags;
+};
+
+static int is_metacharacter(const unsigned char *s) {
+  static const char *metacharacters = "^$().[]*+?|\\Ssdbfnrtv";
+  return strchr(metacharacters, *s) != NULL;
 }
 
-static const char *match(const struct slre *, int, const char *, int, int *,
-                         struct cap *);
+static int op_len(const char *re) {
+  return re[0] == '\\' && re[1] == 'x' ? 4 : re[0] == '\\' ? 2 : 1;
+}
 
-static void loop_greedy(const struct slre *r, int pc, const char *s, int len,
-                        int *ofs) {
-  int  saved_offset, matched_offset;
+static int set_len(const char *re, int re_len) {
+  int len = 0;
 
-  saved_offset = matched_offset = *ofs;
-
-  while (!match(r, pc + 2, s, len, ofs, NULL)) {
-    saved_offset = *ofs;
-    if (!match(r, pc + r->code[pc + 1], s, len, ofs, NULL)) {
-      matched_offset = saved_offset;
-    }
-    *ofs = saved_offset;
+  while (len < re_len && re[len] != ']') {
+    len += op_len(re + len);
   }
 
-  *ofs = matched_offset;
+  return len <= re_len ? len + 1 : -1;
 }
 
-static void loop_non_greedy(const struct slre *r, int pc, const char *s,
-                            int len, int *ofs) {
-  int  saved_offset = *ofs;
+static int get_op_len(const char *re, int re_len) {
+  return re[0] == '[' ? set_len(re + 1, re_len - 1) + 1 : op_len(re);
+}
 
-  while (!match(r, pc + 2, s, len, ofs, NULL)) {
-    saved_offset = *ofs;
-    if (!match(r, pc + r->code[pc + 1], s, len, ofs, NULL))
+static int is_quantifier(const char *re) {
+  return re[0] == '*' || re[0] == '+' || re[0] == '?';
+}
+
+static int toi(int x) {
+  return isdigit(x) ? x - '0' : x - 'W';
+}
+
+static int hextoi(const unsigned char *s) {
+  return (toi(tolower(s[0])) << 4) | toi(tolower(s[1]));
+}
+
+static int match_op(const unsigned char *re, const unsigned char *s,
+                    struct regex_info *info) {
+  int result = 0;
+  switch (*re) {
+    case '\\':
+      /* Metacharacters */
+      switch (re[1]) {
+        case 'S': FAIL_IF(isspace(*s), SLRE_NO_MATCH); result++; break;
+        case 's': FAIL_IF(!isspace(*s), SLRE_NO_MATCH); result++; break;
+        case 'd': FAIL_IF(!isdigit(*s), SLRE_NO_MATCH); result++; break;
+        case 'b': FAIL_IF(*s != '\b', SLRE_NO_MATCH); result++; break;
+        case 'f': FAIL_IF(*s != '\f', SLRE_NO_MATCH); result++; break;
+        case 'n': FAIL_IF(*s != '\n', SLRE_NO_MATCH); result++; break;
+        case 'r': FAIL_IF(*s != '\r', SLRE_NO_MATCH); result++; break;
+        case 't': FAIL_IF(*s != '\t', SLRE_NO_MATCH); result++; break;
+        case 'v': FAIL_IF(*s != '\v', SLRE_NO_MATCH); result++; break;
+
+        case 'x':
+          /* Match byte, \xHH where HH is hexadecimal byte representaion */
+          FAIL_IF(hextoi(re + 2) != *s, SLRE_NO_MATCH);
+          result++;
+          break;
+
+        default:
+          /* Valid metacharacter check is done in bar() */
+          FAIL_IF(re[1] != s[0], SLRE_NO_MATCH);
+          result++;
+          break;
+      }
+      break;
+
+    case '|': FAIL_IF(1, SLRE_INTERNAL_ERROR); break;
+    case '$': FAIL_IF(1, SLRE_NO_MATCH); break;
+    case '.': result++; break;
+
+    default:
+      if (info->flags & SLRE_IGNORE_CASE) {
+        FAIL_IF(tolower(*re) != tolower(*s), SLRE_NO_MATCH);
+      } else {
+        FAIL_IF(*re != *s, SLRE_NO_MATCH);
+      }
+      result++;
       break;
   }
 
-  *ofs = saved_offset;
+  return result;
 }
 
-static int is_any_of(const unsigned char *p, int len, const char *s, int *ofs) {
-  int  i, ch;
+static int match_set(const char *re, int re_len, const char *s,
+                     struct regex_info *info) {
+  int len = 0, result = -1, invert = re[0] == '^';
 
-  ch = s[*ofs];
+  if (invert) re++, re_len--;
 
-  for (i = 0; i < len; i++)
-    if (p[i] == ch) {
-      (*ofs)++;
-      return 1;
-    }
-
-  return 0;
-}
-
-static int is_any_but(const unsigned char *p, int len, const char *s,
-                      int *ofs) {
-  int  i, ch;
-
-  ch = s[*ofs];
-
-  for (i = 0; i < len; i++)
-    if (p[i] == ch) {
-      return 0;
-    }
-
-  (*ofs)++;
-  return 1;
-}
-
-static int lowercase(const char *s) {
-  return tolower(* (const unsigned char *) s);
-}
-
-static int casecmp(const void *p1, const void *p2, size_t len) {
-  const char *s1 = p1, *s2 = p2;
-  int diff = 0;
-
-  if (len > 0)
-    do {
-      diff = lowercase(s1++) - lowercase(s2++);
-    } while (diff == 0 && s1[-1] != '\0' && --len > 0);
-
-  return diff;
-}
-
-static const char *match(const struct slre *r, int pc, const char *s, int len,
-                         int *ofs, struct cap *caps) {
-  int n, saved_offset;
-  const char *error_string = NULL;
-  int (*cmp)(const void *string1, const void *string2, size_t len);
-
-  while (error_string == NULL && r->code[pc] != END) {
-
-    assert(pc < r->code_size);
-    assert(pc < (int) (sizeof(r->code) / sizeof(r->code[0])));
-
-    switch (r->code[pc]) {
-      case BRANCH:
-        saved_offset = *ofs;
-        error_string = match(r, pc + 3, s, len, ofs, caps);
-        if (error_string != NULL) {
-          *ofs = saved_offset;
-          error_string = match(r, pc + r->code[pc + 1], s, len, ofs, caps);
-        }
-        pc += r->code[pc + 2];
-        break;
-
-      case EXACT:
-        error_string = error_no_match;
-        n = r->code[pc + 2];  // String length
-        cmp = r->options & SLRE_CASE_INSENSITIVE ? casecmp : memcmp;
-        if (n <= len - *ofs && !cmp(s + *ofs, r->data + r->code[pc + 1], n)) {
-          (*ofs) += n;
-          error_string = NULL;
-        }
-        pc += 3;
-        break;
-
-      case QUEST:
-        error_string = NULL;
-        saved_offset = *ofs;
-        if (match(r, pc + 2, s, len, ofs, caps) != NULL) {
-          *ofs = saved_offset;
-        }
-        pc += r->code[pc + 1];
-        break;
-
-      case STAR:
-        error_string = NULL;
-        loop_greedy(r, pc, s, len, ofs);
-        pc += r->code[pc + 1];
-        break;
-
-      case STARQ:
-        error_string = NULL;
-        loop_non_greedy(r, pc, s, len, ofs);
-        pc += r->code[pc + 1];
-        break;
-
-      case PLUS:
-        if ((error_string = match(r, pc + 2, s, len, ofs, caps)) != NULL)
-          break;
-
-        loop_greedy(r, pc, s, len, ofs);
-        pc += r->code[pc + 1];
-        break;
-
-      case PLUSQ:
-        if ((error_string = match(r, pc + 2, s, len, ofs, caps)) != NULL)
-          break;
-
-        loop_non_greedy(r, pc, s, len, ofs);
-        pc += r->code[pc + 1];
-        break;
-
-      case SPACE:
-        error_string = error_no_match;
-        if (*ofs < len && isspace(((unsigned char *)s)[*ofs])) {
-          (*ofs)++;
-          error_string = NULL;
-        }
-        pc++;
-        break;
-
-      case NONSPACE:
-        error_string = error_no_match;
-        if (*ofs <len && !isspace(((unsigned char *)s)[*ofs])) {
-          (*ofs)++;
-          error_string = NULL;
-        }
-        pc++;
-        break;
-
-      case DIGIT:
-        error_string = error_no_match;
-        if (*ofs < len && isdigit(((unsigned char *)s)[*ofs])) {
-          (*ofs)++;
-          error_string = NULL;
-        }
-        pc++;
-        break;
-
-      case ANY:
-        error_string = error_no_match;
-        if (*ofs < len) {
-          (*ofs)++;
-          error_string = NULL;
-        }
-        pc++;
-        break;
-
-      case ANYOF:
-        error_string = error_no_match;
-        if (*ofs < len)
-          error_string = is_any_of(r->data + r->code[pc + 1], r->code[pc + 2],
-                                   s, ofs) ? NULL : error_no_match;
-        pc += 3;
-        break;
-
-      case ANYBUT:
-        error_string = error_no_match;
-        if (*ofs < len)
-          error_string = is_any_but(r->data + r->code[pc + 1], r->code[pc + 2],
-                                    s, ofs) ? NULL : error_no_match;
-        pc += 3;
-        break;
-
-      case BOL:
-        error_string = *ofs == 0 ? NULL : error_no_match;
-        pc++;
-        break;
-
-      case EOL:
-        error_string = *ofs == len ? NULL : error_no_match;
-        pc++;
-        break;
-
-      case OPEN:
-        if (caps != NULL)
-          caps[r->code[pc + 1]].ptr = s + *ofs;
-        pc += 2;
-        break;
-
-      case CLOSE:
-        if (caps != NULL)
-          caps[r->code[pc + 1]].len = (s + *ofs) -
-            caps[r->code[pc + 1]].ptr;
-        pc += 2;
-        break;
-
-      case END:
-        pc++;
-        break;
-
-      default:
-        printf("unknown cmd (%d) at %d\n", r->code[pc], pc);
-        assert(0);
-        break;
-    }
-  }
-
-  return error_string;
-}
-
-// Return 1 if match, 0 if no match.
-// If `captured_substrings' array is not NULL, then it is filled with the
-// values of captured substrings. captured_substrings[0] element is always
-// a full matched substring. The round bracket captures start from
-// captured_substrings[1].
-// It is assumed that the size of captured_substrings array is enough to
-// hold all captures. The caller function must make sure it is! So, the
-// array_size = number_of_round_bracket_pairs + 1
-static const char *match2(const struct slre *r, const char *buf, int len,
-                          struct cap *caps) {
-  int  i, ofs = 0;
-  const char *error_string = error_no_match;
-
-  if (r->anchored) {
-    error_string = match(r, 0, buf, len, &ofs, caps);
-  } else {
-    for (i = 0; i < len && error_string != NULL; i++) {
-      ofs = i;
-      error_string = match(r, 0, buf, len, &ofs, caps);
-    }
-  }
-
-  return error_string;
-}
-
-static const char *capture_float(const struct cap *cap, void *p, size_t len) {
-  const char *fmt;
-  char buf[20];
-
-  switch (len) {
-    case sizeof(float): fmt = "f"; break;
-    case sizeof(double): fmt = "lf"; break;
-    default: return "SLRE_FLOAT: unsupported size";
-  }
-
-  snprintf(buf, sizeof(buf), "%%%d%s", cap->len, fmt);
-  return sscanf(cap->ptr, buf, p) == 1 ? NULL : "SLRE_FLOAT: capture failed";
-}
-
-static const char *capture_string(const struct cap *cap, void *p, size_t len) {
-  if ((int) len <= cap->len) {
-    return "SLRE_STRING: buffer size too small";
-  }
-  memcpy(p, cap->ptr, cap->len);
-  ((char *) p)[cap->len] = '\0';
-  return NULL;
-}
-
-static const char *capture_int(const struct cap *cap, void *p, size_t len) {
-  const char *fmt;
-  char buf[20];
-
-  switch (len) {
-    case sizeof(char): fmt = "hh"; break;
-    case sizeof(short): fmt = "h"; break;
-    case sizeof(int): fmt = "d"; break;
-    case sizeof(long long int): fmt = "lld"; break;
-    default: return "SLRE_INT: unsupported size";
-  }
-
-  snprintf(buf, sizeof(buf), "%%%d%s", cap->len, fmt);
-  return sscanf(cap->ptr, buf, p) == 1 ? NULL : "SLRE_INT: capture failed";
-}
-
-static const char *capture(const struct cap *caps, int num_caps, va_list ap) {
-  int i, type;
-  size_t size;
-  void *p;
-  const char *err = NULL;
-
-  for (i = 0; i < num_caps; i++) {
-    type = va_arg(ap, int);
-    size = va_arg(ap, size_t);
-    p = va_arg(ap, void *);
-    switch (type) {
-      case SLRE_INT: err = capture_int(&caps[i], p, size); break;
-      case SLRE_FLOAT: err = capture_float(&caps[i], p, size); break;
-      case SLRE_STRING: err = capture_string(&caps[i], p, size); break;
-      default: err = "Unknown type, expected SLRE_(INT|FLOAT|STRING)"; break;
-    }
-  }
-  return err;
-}
-
-const char *slre_match(enum slre_option options, const char *re,
-                       const char *buf, int buf_len, ...) {
-  struct slre slre;
-  struct cap caps[20];
-  va_list ap;
-  const char *error_string = NULL;
-
-  slre.options = options;
-  if ((error_string = compile2(&slre, re)) == NULL &&
-      (error_string = match2(&slre, buf, buf_len, caps)) == NULL) {
-    va_start(ap, buf_len);
-    error_string = capture(caps + 1, slre.num_caps, ap);
-    va_end(ap);
-  }
-
-  return error_string;
-}
-
-#if defined(SLRE_UNIT_TEST)
-static struct {
-  const char *name;
-  int narg;
-  const char *flags;
-} opcodes[] = {
-  {"END",      0, ""  },  // End of code block or program
-  {"BRANCH",   2, "oo"},  // Alternative operator, "|"
-  {"ANY",      0, ""  },  // Match any character, "."
-  {"EXACT",    2, "d" },  // Match exact string
-  {"ANYOF",    2, "D" },  // Match any from set, "[]"
-  {"ANYBUT",   2, "D" },  // Match any but from set, "[^]"
-  {"OPEN ",    1, "i" },  // Capture start, "("
-  {"CLOSE",    1, "i" },  // Capture end, ")"
-  {"BOL",      0, ""  },  // Beginning of string, "^"
-  {"EOL",      0, ""  },  // End of string, "$"
-  {"STAR",     1, "o" },  // Match zero or more times "*"
-  {"PLUS",     1, "o" },  // Match one or more times, "+"
-  {"STARQ",    1, "o" },  // Non-greedy STAR,  "*?"
-  {"PLUSQ",    1, "o" },  // Non-greedy PLUS, "+?"
-  {"QUEST",    1, "o" },  // Match zero or one time, "?"
-  {"SPACE",    0, ""  },  // Match whitespace, "\s"
-  {"NONSPACE", 0, ""  },  // Match non-space, "\S"
-  {"DIGIT",    0, ""  }   // Match digit, "\d"
-};
-
-static void print_character_set(FILE *fp, const unsigned char *p, int len) {
-  int  i;
-
-  for (i = 0; i < len; i++) {
-    if (i > 0)
-      (void) fputc(',', fp);
-    if (p[i] == 0) {
-      i++;
-      if (p[i] == 0)
-        (void) fprintf(fp, "\\x%02x", p[i]);
-      else
-        (void) fprintf(fp, "%s", opcodes[p[i]].name);
-    } else if (isprint(p[i])) {
-      (void) fputc(p[i], fp);
+  while (len <= re_len && re[len] != ']' && result <= 0) {
+    /* Support character range */
+    if (re[len] != '-' && re[len + 1] == '-' && re[len + 2] != ']' &&
+        re[len + 2] != '\0') {
+      result = info->flags &&  SLRE_IGNORE_CASE ?
+        *s >= re[len] && *s <= re[len + 2] :
+        tolower(*s) >= tolower(re[len]) && tolower(*s) <= tolower(re[len + 2]);
+      len += 3;
     } else {
-      (void) fprintf(fp,"\\x%02x", p[i]);
+      result = match_op((unsigned char *) re + len, (unsigned char *) s, info);
+      len += op_len(re + len);
     }
   }
+  return (!invert && result > 0) || (invert && result <= 0) ? 1 : -1;
 }
 
-static void dump(const struct slre *r, FILE *fp) {
-  int  i, j, ch, op, pc;
+static int doh(const char *s, int s_len, struct regex_info *info, int bi);
 
-  for (pc = 0; pc < r->code_size; pc++) {
+static int bar(const char *re, int re_len, const char *s, int s_len,
+               struct regex_info *info, int bi) {
+  /* i is offset in re, j is offset in s, bi is brackets index */
+  int i, j, n, step;
 
-    op = r->code[pc];
-    (void) fprintf(fp, "%3d %s ", pc, opcodes[op].name);
+  for (i = j = 0; i < re_len && j <= s_len; i += step) {
 
-    for (i = 0; opcodes[op].flags[i] != '\0'; i++)
-      switch (opcodes[op].flags[i]) {
-        case 'i':
-          fprintf(fp, "%d ", r->code[pc + 1]);
-          pc++;
-          break;
-        case 'o':
-          fprintf(fp, "%d ", pc + r->code[pc + 1] - i);
-          pc++;
-          break;
-        case 'D':
-          print_character_set(fp, r->data +
-                              r->code[pc + 1], r->code[pc + 2]);
-          pc += 2;
-          break;
-        case 'd':
-          (void) fputc('"', fp);
-          for (j = 0; j < r->code[pc + 2]; j++) {
-            ch = r->data[r->code[pc + 1] + j];
-            if (isprint(ch))
-              fputc(ch, fp);
-            else
-              fprintf(fp,"\\x%02x",ch);
+    /* Handle quantifiers. Get the length of the chunk. */
+    step = re[i] == '(' ? info->brackets[bi + 1].len + 2 :
+      get_op_len(re + i, re_len - i);
+
+    DBG(("%s [%.*s] [%.*s] re_len=%d step=%d i=%d j=%d\n", __func__,
+         re_len - i, re + i, s_len - j, s + j, re_len, step, i, j));
+
+    FAIL_IF(is_quantifier(&re[i]), SLRE_UNEXPECTED_QUANTIFIER);
+    FAIL_IF(step <= 0, SLRE_INVALID_CHARACTER_SET);
+
+    if (i + step < re_len && is_quantifier(re + i + step)) {
+      DBG(("QUANTIFIER: [%.*s]%c [%.*s]\n", step, re + i,
+           re[i + step], s_len - j, s + j));
+      if (re[i + step] == '?') {
+        int result = bar(re + i, step, s + j, s_len - j, info, bi);
+        j += result > 0 ? result : 0;
+        i++;
+      } else if (re[i + step] == '+' || re[i + step] == '*') {
+        int j2 = j, nj = j, n1, n2 = -1, ni, non_greedy = 0;
+
+        /* Points to the regexp code after the quantifier */
+        ni = i + step + 1;
+        if (ni < re_len && re[ni] == '?') {
+          non_greedy = 1;
+          ni++;
+        }
+
+        do {
+          if ((n1 = bar(re + i, step, s + j2, s_len - j2, info, bi)) > 0) {
+            j2 += n1;
           }
-          (void) fputc('"', fp);
-          pc += 2;
-          break;
+          if (re[i + step] == '+' && n1 < 0) break;
+
+          if (ni >= re_len) {
+            /* After quantifier, there is nothing */
+            nj = j2;
+          } else if ((n2 = bar(re + ni, re_len - ni, s + j2,
+                               s_len - j2, info, bi)) >= 0) {
+            /* Regex after quantifier matched */
+            nj = j2 + n2;
+          }
+          if (nj > j && non_greedy) break;
+        } while (n1 > 0);
+
+        if (n1 < 0 && re[i + step] == '*' &&
+            (n2 = bar(re + ni, re_len - ni, s + j, s_len - j, info, bi)) > 0) {
+          nj = j + n2;
+        }
+
+        DBG(("STAR/PLUS END: %d %d %d %d %d\n", j, nj, re_len - ni, n1, n2));
+        FAIL_IF(re[i + step] == '+' && nj == j, SLRE_NO_MATCH);
+
+        /* If while loop body above was not executed for the * quantifier,  */
+        /* make sure the rest of the regex matches                          */
+        FAIL_IF(nj == j && ni < re_len && n2 < 0, SLRE_NO_MATCH);
+
+        /* Returning here cause we've matched the rest of RE already */
+        return nj;
+      }
+      continue;
+    }
+
+    if (re[i] == '[') {
+      n = match_set(re + i + 1, re_len - (i + 2), s + j, info);
+      DBG(("SET %.*s [%.*s] -> %d\n", step, re + i, s_len - j, s + j, n));
+      FAIL_IF(n <= 0, SLRE_NO_MATCH);
+      j += n;
+    } else if (re[i] == '(') {
+      n = SLRE_NO_MATCH;
+      bi++;
+      FAIL_IF(bi >= info->num_brackets, SLRE_INTERNAL_ERROR);
+      DBG(("CAPTURING [%.*s] [%.*s] [%s]\n",
+           step, re + i, s_len - j, s + j, re + i + step));
+
+      if (re_len - (i + step) <= 0) {
+        /* Nothing follows brackets */
+        n = doh(s + j, s_len - j, info, bi);
+      } else {
+        int j2;
+        for (j2 = 0; j2 <= s_len - j; j2++) {
+          if ((n = doh(s + j, s_len - (j + j2), info, bi)) >= 0 &&
+              bar(re + i + step, re_len - (i + step),
+                  s + j + n, s_len - (j + n), info, bi) >= 0) break;
+        }
       }
 
-    fputc('\n', fp);
-  }
-}
-
-
-int main(void) {
-  static const struct { const char *str, *regex, *msg; } tests[] = {
-    {"aa", ".+", NULL},
-    {"aa", ".", NULL},
-    {"", ".", "No match"},
-    {" cc 1234", "c.\\s\\d+", NULL},
-  };
-  char buf[20];
-  int int_value;
-  const char *msg, *str, *re;
-  size_t i;
-
-  char method[10], uri[100];
-  int http_version_minor, http_version_major;
-  const char *error;
-  const char *request = " \tGET /index.html HTTP/1.0\r\n\r\n";
-
-  error = slre_match(0, "^\\s*(GET|POST)\\s+(\\S+)\\s+HTTP/(\\d)\\.(\\d)",
-                     request, strlen(request),
-                     SLRE_STRING,  sizeof(method), method,
-                     SLRE_STRING, sizeof(uri), uri,
-                     SLRE_INT, sizeof(http_version_major), &http_version_major,
-                     SLRE_INT, sizeof(http_version_minor), &http_version_minor);
-
-  if (error != NULL) {
-    printf("Error parsing HTTP request: %s\n", error);
-  } else {
-    printf("Requested URI: %s\n", uri);
-  }
-
-  for (i = 0; i < sizeof(tests) / sizeof(tests[0]); i++) {
-    if ((msg = slre_match(0, tests[i].regex, tests[i].str,
-                          strlen(tests[i].str), NULL)) != tests[i].msg) {
-      printf("Test %zd failed: [%s] [%s] -> [%s]\n", i, tests[i].str,
-             tests[i].regex, msg ? msg : "(null)");
-      return EXIT_FAILURE;
+      DBG(("CAPTURED [%.*s] [%.*s]:%d\n", step, re + i, s_len - j, s + j, n));
+      FAIL_IF(n < 0, n);
+      if (info->caps != NULL) {
+        info->caps[bi - 1].ptr = s + j;
+        info->caps[bi - 1].len = n;
+      }
+      j += n;
+    } else if (re[i] == '^') {
+      FAIL_IF(j != 0, SLRE_NO_MATCH);
+    } else if (re[i] == '$') {
+      FAIL_IF(j != s_len, SLRE_NO_MATCH);
+    } else {
+      FAIL_IF(j >= s_len, SLRE_NO_MATCH);
+      n = match_op((unsigned char *) (re + i), (unsigned char *) (s + j), info);
+      FAIL_IF(n <= 0, n);
+      j += n;
     }
   }
 
-  assert(slre_match(0, "a (\\d+)4\\s*(\\S+)", "aa 1234 xy\nz", 12,
-                    SLRE_INT, sizeof(int_value), &int_value,
-                    SLRE_STRING, sizeof(buf), buf) == NULL);
-  assert(int_value == 123);
-  assert(!strcmp(buf, "xy"));
-
-  str = "Hello превед!";
-  re = "^hello (\\S+)";
-  assert(strcmp(error_no_match, slre_match(0, re, str, strlen(str), SLRE_STRING,
-                                           sizeof(buf), buf)) == 0);
-  assert(slre_match(SLRE_CASE_INSENSITIVE, re, str, strlen(str),
-                    SLRE_STRING, sizeof(buf), buf) == NULL);
-  assert(!strcmp(buf, "превед!"));
-
-  assert(strcmp(error_no_match, slre_match(0, "bC", "aBc", 3)) == 0);
-  assert(slre_match(SLRE_CASE_INSENSITIVE, "bC", "aBc", 3) == NULL);
-
-  printf("%s\n", "All tests passed");
-  return EXIT_SUCCESS;
+  return j;
 }
-#endif // SLRE_UNIT_TEST
+
+/* Process branch points */
+static int doh(const char *s, int s_len, struct regex_info *info, int bi) {
+  const struct bracket_pair *b = &info->brackets[bi];
+  int i = 0, len, result;
+  const char *p;
+
+  do {
+    p = i == 0 ? b->ptr : info->branches[b->branches + i - 1].schlong + 1;
+    len = b->num_branches == 0 ? b->len :
+      i == b->num_branches ? (int) (b->ptr + b->len - p) :
+      (int) (info->branches[b->branches + i].schlong - p);
+    DBG(("%s %d %d [%.*s] [%.*s]\n", __func__, bi, i, len, p, s_len, s));
+    result = bar(p, len, s, s_len, info, bi);
+    DBG(("%s <- %d\n", __func__, result));
+  } while (result <= 0 && i++ < b->num_branches);  /* At least 1 iteration */
+
+  return result;
+}
+
+static int baz(const char *s, int s_len, struct regex_info *info) {
+  int i, result = -1, is_anchored = info->brackets[0].ptr[0] == '^';
+
+  for (i = 0; i <= s_len; i++) {
+    result = doh(s + i, s_len - i, info, 0);
+    if (result >= 0) {
+      result += i;
+      break;
+    }
+    if (is_anchored) break;
+  }
+
+  return result;
+}
+
+static void setup_branch_points(struct regex_info *info) {
+  int i, j;
+  struct branch tmp;
+
+  /* First, sort branches. Must be stable, no qsort. Use bubble algo. */
+  for (i = 0; i < info->num_branches; i++) {
+    for (j = i + 1; j < info->num_branches; j++) {
+      if (info->branches[i].bracket_index > info->branches[j].bracket_index) {
+        tmp = info->branches[i];
+        info->branches[i] = info->branches[j];
+        info->branches[j] = tmp;
+      }
+    }
+  }
+
+  /*
+   * For each bracket, set their branch points. This way, for every bracket
+   * (i.e. every chunk of regex) we know all branch points before matching.
+   */
+  for (i = j = 0; i < info->num_brackets; i++) {
+    info->brackets[i].num_branches = 0;
+    info->brackets[i].branches = j;
+    while (j < info->num_branches && info->branches[j].bracket_index == i) {
+      info->brackets[i].num_branches++;
+      j++;
+    }
+  }
+}
+
+static int foo(const char *re, int re_len, const char *s, int s_len,
+               struct regex_info *info) {
+  int i, step, depth = 0;
+
+  /* First bracket captures everything */
+  info->brackets[0].ptr = re;
+  info->brackets[0].len = re_len;
+  info->num_brackets = 1;
+
+  /* Make a single pass over regex string, memorize brackets and branches */
+  for (i = 0; i < re_len; i += step) {
+    step = get_op_len(re + i, re_len - i);
+
+    if (re[i] == '|') {
+      FAIL_IF(info->num_branches >= (int) ARRAY_SIZE(info->branches),
+              SLRE_TOO_MANY_BRANCHES);
+      info->branches[info->num_branches].bracket_index =
+        info->brackets[info->num_brackets - 1].len == -1 ?
+        info->num_brackets - 1 : depth;
+      info->branches[info->num_branches].schlong = &re[i];
+      info->num_branches++;
+    } else if (re[i] == '\\') {
+      FAIL_IF(i >= re_len - 1, SLRE_INVALID_METACHARACTER);
+      if (re[i + 1] == 'x') {
+        /* Hex digit specification must follow */
+        FAIL_IF(re[i + 1] == 'x' && i >= re_len - 3,
+                SLRE_INVALID_METACHARACTER);
+        FAIL_IF(re[i + 1] ==  'x' && !(isxdigit(re[i + 2]) &&
+                isxdigit(re[i + 3])), SLRE_INVALID_METACHARACTER);
+      } else {
+        FAIL_IF(!is_metacharacter((unsigned char *) re + i + 1),
+                SLRE_INVALID_METACHARACTER);
+      }
+    } else if (re[i] == '(') {
+      FAIL_IF(info->num_brackets >= (int) ARRAY_SIZE(info->brackets),
+              SLRE_TOO_MANY_BRACKETS);
+      depth++;  /* Order is important here. Depth increments first. */
+      info->brackets[info->num_brackets].ptr = re + i + 1;
+      info->brackets[info->num_brackets].len = -1;
+      info->num_brackets++;
+      FAIL_IF(info->num_caps > 0 && info->num_brackets - 1 > info->num_caps,
+              SLRE_CAPS_ARRAY_TOO_SMALL);
+    } else if (re[i] == ')') {
+      int ind = info->brackets[info->num_brackets - 1].len == -1 ?
+        info->num_brackets - 1 : depth;
+      info->brackets[ind].len = (int) (&re[i] - info->brackets[ind].ptr);
+      DBG(("SETTING BRACKET %d [%.*s]\n",
+           ind, info->brackets[ind].len, info->brackets[ind].ptr));
+      depth--;
+      FAIL_IF(depth < 0, SLRE_UNBALANCED_BRACKETS);
+      FAIL_IF(i > 0 && re[i - 1] == '(', SLRE_NO_MATCH);
+    }
+  }
+
+  FAIL_IF(depth != 0, SLRE_UNBALANCED_BRACKETS);
+  setup_branch_points(info);
+
+  return baz(s, s_len, info);
+}
+
+int slre_match(const char *regexp, const char *s, int s_len,
+               struct slre_cap *caps, int num_caps, int flags) {
+  struct regex_info info;
+
+  /* Initialize info structure */
+  info.flags = flags;
+  info.num_brackets = info.num_branches = 0;
+  info.num_caps = num_caps;
+  info.caps = caps;
+
+  DBG(("========================> [%s] [%.*s]\n", regexp, s_len, s));
+  return foo(regexp, (int) strlen(regexp), s, s_len, &info);
+}

--- a/c/slre.h
+++ b/c/slre.h
@@ -1,85 +1,60 @@
-// Copyright (c) 2004-2012 Sergey Lyubka <valenok@gmail.com>
-// All rights reserved
-//
-// Permission is hereby granted, free of charge, to any person obtaining a copy
-// of this software and associated documentation files (the "Software"), to deal
-// in the Software without restriction, including without limitation the rights
-// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-// copies of the Software, and to permit persons to whom the Software is
-// furnished to do so, subject to the following conditions:
-//
-// The above copyright notice and this permission notice shall be included in
-// all copies or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-// THE SOFTWARE.
+/*
+ * Copyright (c) 2004-2013 Sergey Lyubka <valenok@gmail.com>
+ * Copyright (c) 2013 Cesanta Software Limited
+ * All rights reserved
+ *
+ * This library is dual-licensed: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation. For the terms of this
+ * license, see <http://www.gnu.org/licenses/>.
+ *
+ * You are free to use this library under the terms of the GNU General
+ * Public License, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * Alternatively, you can license this library under a commercial
+ * license, as set out in <http://cesanta.com/products.html>.
+ */
+
+/*
+ * This is a regular expression library that implements a subset of Perl RE.
+ * Please refer to README.md for a detailed reference.
+ */
 
 #ifndef SLRE_HEADER_DEFINED
 #define SLRE_HEADER_DEFINED
 
-// This is a regular expression library that implements a subset of Perl RE.
-// Please refer to http://slre.googlecode.com for detailed description.
-//
-// Supported syntax:
-//    ^        Match beginning of a buffer
-//    $        Match end of a buffer
-//    ()       Grouping and substring capturing
-//    [...]    Match any character from set
-//    [^...]   Match any character but ones from set
-//    \s       Match whitespace
-//    \S       Match non-whitespace
-//    \d       Match decimal digit
-//    \r       Match carriage return
-//    \n       Match newline
-//    +        Match one or more times (greedy)
-//    +?       Match one or more times (non-greedy)
-//    *        Match zero or more times (greedy)
-//    *?       Match zero or more times (non-greedy)
-//    ?        Match zero or once
-//    \xDD     Match byte with hex value 0xDD
-//    \meta    Match one of the meta character: ^$().[*+\?
+#ifdef __cplusplus
+extern "C" {
+#endif
 
-// Match string buffer "buf" of length "buf_len" against "regexp", which should
-// conform the syntax outlined above. "options" could be either 0 or
-// SLRE_CASE_INSENSITIVE for case-insensitive match. If regular expression
-// "regexp" contains brackets, slre_match() will capture the respective
-// substring into the passed placeholder. Thus, each opening parenthesis
-// should correspond to three arguments passed:
-//   placeholder_type, placeholder_size, placeholder_address
-//
-// Usage example: parsing HTTP request line.
-//
-//  char method[10], uri[100];
-//  int http_version_minor, http_version_major;
-//  const char *error;
-//  const char *request = " \tGET /index.html HTTP/1.0\r\n\r\n";
+struct slre_cap {
+  const char *ptr;
+  int len;
+};
 
-//  error = slre_match(0, "^\\s*(GET|POST)\\s+(\\S+)\\s+HTTP/(\\d)\\.(\\d)",
-//                     request, strlen(request),
-//                     SLRE_STRING,  sizeof(method), method,
-//                     SLRE_STRING, sizeof(uri), uri,
-//                     SLRE_INT,sizeof(http_version_major),&http_version_major,
-//                     SLRE_INT,sizeof(http_version_minor),&http_version_minor);
-//
-//  if (error != NULL) {
-//    printf("Error parsing HTTP request: %s\n", error);
-//  } else {
-//    printf("Requested URI: %s\n", uri);
-//  }
-//
-//
-// Return:
-//   NULL: string matched and all captures successfully made
-//   non-NULL: in this case, the return value is an error string
 
-enum slre_option {SLRE_CASE_INSENSITIVE = 1};
-enum slre_capture {SLRE_STRING, SLRE_INT, SLRE_FLOAT};
-const char *slre_match(enum slre_option options, const char *regexp,
-                       const char *buf, int buf_len, ...);
+int slre_match(const char *regexp, const char *buf, int buf_len,
+               struct slre_cap *caps, int num_caps, int flags);
 
-#endif /* SLRE_HEADER_DEFINED */
+/* Possible flags for slre_match() */
+enum { SLRE_IGNORE_CASE = 1 };
+
+
+/* slre_match() failure codes */
+#define SLRE_NO_MATCH               -1
+#define SLRE_UNEXPECTED_QUANTIFIER  -2
+#define SLRE_UNBALANCED_BRACKETS    -3
+#define SLRE_INTERNAL_ERROR         -4
+#define SLRE_INVALID_CHARACTER_SET  -5
+#define SLRE_INVALID_METACHARACTER  -6
+#define SLRE_CAPS_ARRAY_TOO_SMALL   -7
+#define SLRE_TOO_MANY_BRANCHES      -8
+#define SLRE_TOO_MANY_BRACKETS      -9
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  /* SLRE_HEADER_DEFINED */

--- a/c/strutil.c
+++ b/c/strutil.c
@@ -1,5 +1,24 @@
 /* read XDI file in C */
 
+/* This file is free and unencumbered software released into the public domain. */
+/*                                                                              */
+/* Anyone is free to copy, modify, publish, use, compile, sell, or              */
+/* distribute this software, either in source code form or as a compiled        */
+/* binary, for any purpose, commercial or non-commercial, and by any            */
+/* means.                                                                       */
+/*                                                                              */
+/* In jurisdictions that recognize copyright laws, the author or authors        */
+/* of this software dedicate any and all copyright interest in the              */
+/* software to the public domain.                                               */
+/*                                                                              */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,              */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF           */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.       */
+/* IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR            */
+/* OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,        */
+/* ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR        */
+/* OTHER DEALINGS IN THE SOFTWARE.                                              */
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/c/strutil.h
+++ b/c/strutil.h
@@ -1,3 +1,22 @@
+/* This file is free and unencumbered software released into the public domain. */
+/*                                                                              */
+/* Anyone is free to copy, modify, publish, use, compile, sell, or              */
+/* distribute this software, either in source code form or as a compiled        */
+/* binary, for any purpose, commercial or non-commercial, and by any            */
+/* means.                                                                       */
+/*                                                                              */
+/* In jurisdictions that recognize copyright laws, the author or authors        */
+/* of this software dedicate any and all copyright interest in the              */
+/* software to the public domain.                                               */
+/*                                                                              */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,              */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF           */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.       */
+/* IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR            */
+/* OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,        */
+/* ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR        */
+/* OTHER DEALINGS IN THE SOFTWARE.                                              */
+
 #define CR "\n"
 #define CRLF "\n\r"
 

--- a/c/test_valgrind.pl
+++ b/c/test_valgrind.pl
@@ -2,7 +2,7 @@
 
 use strict;
 use warnings;
-use Test::More tests => 90;
+use Test::More tests => 144;
 
 ## good data
 foreach my $file (qw(co_metal_rt.xdi
@@ -23,7 +23,8 @@ foreach my $file (qw(co_metal_rt.xdi
 		   )) {
   my $command = "valgrind --track-origins=yes --leak-check=full --show-leak-kinds=all ./xdi_reader ../data/$file 2>&1";
   my $x = `$command`;
-  ok(($x =~ m{All heap blocks were freed}), $file);
+  ok(($x =~ m{All heap blocks were freed}), "blocks: $file");
+  ok(($x =~ m{0 errors}), "errors: $file");
   ok((not $?), "$file return value is 0");
 };
 
@@ -33,14 +34,16 @@ my %return = ('00' => 0, '01' => 1, '02' => 0, '03' => 0, '04' => 0, '05' => 0,
 	      '06' => 0, '07' => 0, '08' => 0, '09' => 0, '10' => 0, '11' => 0,
 	      '12' => 0, '13' => 1, '14' => 1, '15' => 1, '16' => 1, '17' => 1,
 	      '18' => 1, '19' => 1, '20' => 1, '21' => 1, '22' => 1, '23' => 0,
-	      '24' => 1, '25' => 0, '26' => 0, '27' => 0, '28' => 1, '29' => 1, );
+	      '24' => 1, '25' => 0, '26' => 0, '27' => 0, '28' => 0, '29' => 0,
+	      '30' => 0, '31' => 0, '32' => 0);
 
 ## bad data
-foreach my $i (0 .. 29) {
+foreach my $i (0 .. 32) {
   my $n = sprintf("%2.2d", $i);
   my $command = "valgrind --track-origins=yes --leak-check=full --show-leak-kinds=all ./xdi_reader ../baddata/bad_$n.xdi 2>&1";
   my $x = `$command`;
-  ok(($x =~ m{All heap blocks were freed}), "bad_$n.xdi");
+  ok(($x =~ m{All heap blocks were freed}), "blocks: bad_$n.xdi");
+  ok(($x =~ m{0 errors}), "errors: bad_$n.xdi");
   ok((not ($? xor $return{$n})), "bad_$n.xdi return value is $?");
 };
 

--- a/c/xdi_reader.c
+++ b/c/xdi_reader.c
@@ -33,24 +33,28 @@ int main(int argc, char **argv) {
   /* read xdifile */
   xdifile = malloc(sizeof(XDIFile));
   ret = XDI_readfile(argv[1], xdifile);
+
+  /* react to a terminal error */
   if (ret < 0) {
     printf("Error reading XDI file '%s':\n     %s\t(error code = %ld)\n",
-	   argv[1], XDI_errorstring(ret), ret);
+	   argv[1], xdifile->error_message, ret);
     XDI_cleanup(xdifile, ret);
     return 1;
   }
 
+  /* react to a warning */
   if (ret > 0) {
-    printf("Warning reading XDI file '%s':\n     %s\t(error code = %ld)\n\n",
-	   argv[1], XDI_errorstring(ret), ret);
+    printf("Warning reading XDI file '%s':\n     %s\t(warning code = %ld)\n\n",
+	   argv[1], xdifile->error_message, ret);
   }
 
+  /* print some basic information about the file to the screen */
   printf("#------\n# XDI FILE Read %s VERSIONS: |%s|%s|\n" ,
 	 xdifile->filename, xdifile->xdi_version, xdifile->extra_version);
-
   printf("# Elem/Edge: %s|%s|\n", xdifile->element, xdifile->edge);
   printf("# User Comments:\n%s\n", xdifile->comments);
 
+  /* print all the metadata to the screen, validate each item */
   printf("# Metadata(%ld entries):\n", xdifile->nmetadata);
   printf(" --- \n");
   for (i=0; i < xdifile->nmetadata; i++) {
@@ -61,15 +65,20 @@ int main(int argc, char **argv) {
 
     j = XDI_validate_item(xdifile, xdifile->meta_families[i], xdifile->meta_keywords[i], xdifile->meta_values[i]);
     if (j!=0) {
-      printf("-- Warning for %s.%s: %s\t(error code = %ld)\n\t%s\n",
+      printf("-- Warning for %s.%s: %s\t(warning code = %ld)\n\t%s\n",
 	     xdifile->meta_families[i], xdifile->meta_keywords[i], xdifile->meta_values[i], j, xdifile->error_message);
     }
   }
 
+  /* do the test for REQUIRED metadata */
   j = XDI_required_metadata(xdifile);
-  printf("-- required metadata check -- (requirement code %ld):\n%s\n", j, xdifile->error_message);
+  printf("\n# check for required metadata -- (requirement code %ld):\n%s\n", j, xdifile->error_message);
 
+  /* do the test for RECOMMENDED metadata */
+  j = XDI_recommended_metadata(xdifile);
+  printf("\n# check for recommended metadata -- (recommendation code %ld):\n%s\n", j, xdifile->error_message);
 
+  /* print the data table to the screen */
   nout = min(4, xdifile->npts - 2);
   printf("# Arrays Index, Name, Values: (%ld points total): \n", xdifile->npts);
   tdat = (double *)calloc(xdifile->npts, sizeof(double));
@@ -93,6 +102,8 @@ int main(int argc, char **argv) {
     }
     printf("\n");
   }
+
+  /* free memory before leaving */
   free(tdat);
   XDI_cleanup(xdifile, 0);
   return 0;

--- a/c/xdi_reader.c
+++ b/c/xdi_reader.c
@@ -58,7 +58,17 @@ int main(int argc, char **argv) {
 	   xdifile->meta_families[i],
 	   xdifile->meta_keywords[i],
 	   xdifile->meta_values[i]);
+
+    j = XDI_validate_item(xdifile, xdifile->meta_families[i], xdifile->meta_keywords[i], xdifile->meta_values[i]);
+    if (j!=0) {
+      printf("-- Warning for %s.%s: %s\t(error code = %ld)\n\t%s\n",
+	     xdifile->meta_families[i], xdifile->meta_keywords[i], xdifile->meta_values[i], j, xdifile->error_message);
+    }
   }
+
+  j = XDI_required_metadata(xdifile);
+  printf("-- required metadata check -- (requirement code %ld):\n%s\n", j, xdifile->error_message);
+
 
   nout = min(4, xdifile->npts - 2);
   printf("# Arrays Index, Name, Values: (%ld points total): \n", xdifile->npts);

--- a/c/xdi_reader.c
+++ b/c/xdi_reader.c
@@ -39,6 +39,7 @@ int main(int argc, char **argv) {
     printf("Error reading XDI file '%s':\n     %s\t(error code = %ld)\n",
 	   argv[1], xdifile->error_message, ret);
     XDI_cleanup(xdifile, ret);
+    free(xdifile);
     return 1;
   }
 
@@ -106,5 +107,6 @@ int main(int argc, char **argv) {
   /* free memory before leaving */
   free(tdat);
   XDI_cleanup(xdifile, 0);
+  free(xdifile);
   return 0;
 }

--- a/c/xdifile.c
+++ b/c/xdifile.c
@@ -342,10 +342,10 @@ XDI_readfile(char *filename, XDIFile *xdifile) {
 
 	/* MONO D-SPACING */
 	} else if (strcasecmp(mkey, TOK_DSPACE) == 0) {
-	  if (0 != xdi_strtod(mval, &dval)) {
+	  if (0 == xdi_strtod(mval, &dval)) {
 	    xdifile->dspacing = dval;
 	  } else {
-	    xdifile->dspacing = -1;
+	    xdifile->dspacing = -1.0;
 	  };
 
 	/* OUTER ARRAY NAME */

--- a/c/xdifile.c
+++ b/c/xdifile.c
@@ -972,7 +972,7 @@ XDI_cleanup(XDIFile *xdifile, long err) {
       (err != ERR_META_KEYNAME) &&
       (err != ERR_META_FORMAT))    {
     free(xdifile->filename);
-  };
+  }
 
   if ((err < -1) || (err == 0)) {
 
@@ -985,7 +985,7 @@ XDI_cleanup(XDIFile *xdifile, long err) {
       free(xdifile->array);
       free(xdifile->array_labels);
       free(xdifile->array_units);
-    };
+    }
 
     for (j = 0; j < xdifile->nmetadata; j++) {
       free(xdifile->meta_families[j]);
@@ -1003,8 +1003,6 @@ XDI_cleanup(XDIFile *xdifile, long err) {
     if (err == 0) {
       free(xdifile->outer_array);
       free(xdifile->outer_breakpts);
-    };
+    }
   }
-
-  free(xdifile);
 }

--- a/c/xdifile.c
+++ b/c/xdifile.c
@@ -203,7 +203,7 @@ XDI_readfile(char *filename, XDIFile *xdifile) {
     firstline[strcspn(firstline, CRLF)] = '\0';
     nwords = make_words(firstline, cwords, 2);
     if (nwords < 1) {
-      strcpy(xdifile->error_message, "not an XDI file, no versioning information in first line");
+      strcpy(xdifile->error_message, "not an XDI file, no XDI versioning information in first line");
       for (j=0; j<=ilen; j++) {
 	free(textlines[j]);
       }
@@ -213,7 +213,7 @@ XDI_readfile(char *filename, XDIFile *xdifile) {
       return ERR_NOTXDI;
     }
     if (strncasecmp(cwords[0], TOK_VERSION, strlen(TOK_VERSION)) != 0)  {
-      strcpy(xdifile->error_message, "not an XDI file, missing \"XDI/\" token in first line");
+      strcpy(xdifile->error_message, "not an XDI file, no XDI versioning information in first line");
       for (j=0; j<=ilen; j++) {
 	free(textlines[j]);
       }
@@ -653,10 +653,10 @@ XDI_required_metadata(XDIFile *xdifile) {
   }
 
   strcpy(xdifile->error_message, "");
-  if (ret & REQ_ELEM)             { strcat(xdifile->error_message, "\tElement.symbol missing or not valid (1)\n"); }
-  if (ret & REQ_EDGE)             { strcat(xdifile->error_message, "\tElement.edge missing or not valid (2)\n"); }
-  if (ret & REQ_NO_DSPACING)      { strcat(xdifile->error_message, "\tMono.d_spacing missing (4)\n"); }
-  if (ret & REQ_INVALID_DSPACING) { strcat(xdifile->error_message, "\tMono.d_spacing not valid (8)\n"); }
+  if (ret & REQ_ELEM)             { strcat(xdifile->error_message, "Element.symbol missing or not valid\n"); }
+  if (ret & REQ_EDGE)             { strcat(xdifile->error_message, "Element.edge missing or not valid\n"); }
+  if (ret & REQ_NO_DSPACING)      { strcat(xdifile->error_message, "Mono.d_spacing missing\n"); }
+  if (ret & REQ_INVALID_DSPACING) { strcat(xdifile->error_message, "Mono.d_spacing not valid\n"); }
 
   return ret;
 }
@@ -864,7 +864,7 @@ int XDI_validate_element(XDIFile *xdifile, char *name, char *value) {
 	break;
       }
     }
-    if (err>0) { strcpy(xdifile->error_message, "element.symbol not given or not valid"); }
+    if (err>0) { strcpy(xdifile->error_message, "element.symbol missing or not valid"); }
 
   } else if (strcasecmp(name, "edge") == 0) {
     err = WRN_NOEDGE;
@@ -874,7 +874,7 @@ int XDI_validate_element(XDIFile *xdifile, char *name, char *value) {
 	break;
       }
     }
-    if (err!=0) { strcpy(xdifile->error_message, "element.edge not given or not valid"); }
+    if (err!=0) { strcpy(xdifile->error_message, "element.edge missing or not valid"); }
 
   } else if (strcasecmp(name, "reference") == 0) {
     err = WRN_REFELEM;
@@ -884,7 +884,7 @@ int XDI_validate_element(XDIFile *xdifile, char *name, char *value) {
 	break;
       }
     }
-    if (err!=0) { strcpy(xdifile->error_message, "element.reference not given or not valid"); }
+    if (err!=0) { strcpy(xdifile->error_message, "element.reference not valid"); }
 
   } else if (strcasecmp(name, "ref_edge") == 0) {
     err = WRN_REFEDGE;
@@ -894,7 +894,7 @@ int XDI_validate_element(XDIFile *xdifile, char *name, char *value) {
 	break;
       }
     }
-    if (err!=0) { strcpy(xdifile->error_message, "element.ref_edge not given or not valid"); }
+    if (err!=0) { strcpy(xdifile->error_message, "element.ref_edge not valid"); }
 
   } else {
     err = 0;

--- a/c/xdifile.c
+++ b/c/xdifile.c
@@ -570,16 +570,22 @@ XDI_readfile(char *filename, XDIFile *xdifile) {
 /* ============================================================================ */
 /* array management section                                                     */
 
+#define ENOUGH ((8 * sizeof(int) - 1) / 3 + 2)
+
 _EXPORT(int)
 XDI_get_array_index(XDIFile *xdifile, long n, double *out) {
   /* get array by index (starting at 0) from an XDIFile structure */
   long j;
+  char str[ENOUGH];
   if (n < xdifile->narrays) {
     for (j = 0; j < xdifile->npts; j++) {
       out[j] = xdifile->array[n][j];
     }
     return 0;
   }
+  strcpy(xdifile->error_message, "no array of index ");
+  sprintf(str, "%ld", n);
+  strcat(xdifile->error_message, str);
   return -1;
 }
 
@@ -592,6 +598,8 @@ XDI_get_array_name(XDIFile *xdifile, char *name, double *out) {
       return XDI_get_array_index(xdifile, i, out);
     }
   }
+  strcpy(xdifile->error_message, "no array of name ");
+  strcat(xdifile->error_message, name);
   return -1;
 }
 
@@ -780,6 +788,9 @@ int XDI_validate_mono(XDIFile *xdifile, char *name, char *value) {
   return err;
 }
 
+/* all tests in the Sample familty should return WRN_BAD_SAMPLE if the */
+/* value does not match the definition.  error_message should explain  */
+/* the problem in a way that is appropruiate to the metadata item */
 int XDI_validate_sample(XDIFile *xdifile, char *name, char *value) {
   int err;
   int regex_status;

--- a/c/xdifile.c
+++ b/c/xdifile.c
@@ -611,7 +611,7 @@ XDI_defined_family(XDIFile *xdifile, char *family) {
       (strcasecmp(family, "sample")   == 0) ||
       (strcasecmp(family, "scan")     == 0) ||
       (strcasecmp(family, "element")  == 0) ||
-      (strcasecmp(family, "column")   == 0)) {
+      (strcasecmp(family, "column")   == 0))  {
     return 1;
   } else {
     return 0;
@@ -662,11 +662,11 @@ XDI_required_metadata(XDIFile *xdifile) {
 }
 
 
-/* Facility.name:            1     */
-/* Facility.source:          2     */
-/* Beamline.name:            4     */
-/* Scan.start_time:          8     */
-/* Column.1=(energy|angle): 16, 32 */
+/* Facility.name:             1 */
+/* Facility.source:           2 */
+/* Beamline.name:             4 */
+/* Scan.start_time:           8 */
+/* Column.1: (energy|angle): 16 */
 
 _EXPORT(int)
 XDI_recommended_metadata(XDIFile *xdifile) {
@@ -706,7 +706,6 @@ XDI_recommended_metadata(XDIFile *xdifile) {
   if (ret & 16) { strcat(xdifile->error_message, "Missing recommended metadata field: Column.1\n"); }
 
   return ret;
-
 }
 
 
@@ -830,6 +829,7 @@ int XDI_validate_scan(XDIFile *xdifile, char *name, char *value) {
 
   /* printf("======== %s %s\n", name, value); */
 
+  err = 0;
   strcpy(xdifile->error_message, "");
 
   if (strcasecmp(name, "start_time") == 0) {
@@ -854,6 +854,7 @@ int XDI_validate_element(XDIFile *xdifile, char *name, char *value) {
   int n_edges = sizeof(ValidEdges)/sizeof(char*);
   int n_elems = sizeof(ValidElems)/sizeof(char*);
 
+  err = 0;
   strcpy(xdifile->error_message, "");
 
   if (strcasecmp(name, "symbol") == 0) {

--- a/c/xdifile.h
+++ b/c/xdifile.h
@@ -24,6 +24,7 @@ typedef struct {
   char *edge;            /* name of absorption edge: "K", "L1", ... */
   char *comments;        /* multi-line, user-supplied comment */
   char *error_line;      /* text of line with any existing error */
+  char *error_message;
   char **array_labels;   /* labels for arrays */
   char *outer_label;     /* labels for outer array */
   char **array_units;    /* units for arrays */
@@ -39,26 +40,30 @@ typedef struct {
 _EXPORT(int) XDI_readfile(char *filename, XDIFile *xdifile) ;
 _EXPORT(int) XDI_get_array_index(XDIFile *xdifile, long n, double *out);
 _EXPORT(int) XDI_get_array_name(XDIFile *xdifile, char *name, double *out);
-_EXPORT(void) XDI_cleanup(XDIFile *xdifile, long err) ;
-
+_EXPORT(int) XDI_required_metadata(XDIFile *xdifile);
+_EXPORT(int) XDI_defined_family(XDIFile *xdifile, char *family);
+_EXPORT(int) XDI_validate_item(XDIFile *xdifile, char *family, char *name, char *value);
+_EXPORT(void) XDI_cleanup(XDIFile *xdifile, long err);
 
 /* Tokens used in XDI File */
 
-#define TOK_VERSION  "XDI/"           /* version marker in file -- required on line 1 */
-#define TOK_COMM     "#"              /* comment character, at start of line */
-#define TOK_DELIM    ":"              /* delimiter between metadata name and value */
-#define TOK_DOT      "."              /* delimiter between metadata family and key */
-#define TOK_EDGE     "element.edge"   /* absorbption edge name */
-#define TOK_ELEM     "element.symbol" /* atomic symbol of absorbing element */
-#define TOK_COLUMN   "column."        /* column label (followed by integer <= 64) */
-#define TOK_DSPACE   "mono.d_spacing" /* mono d_spacing, in Angstroms */
+#define TOK_VERSION    "XDI/"            /* version marker in file -- required on line 1 */
+#define TOK_COMM       "#"               /* comment character, at start of line */
+#define TOK_DELIM      ":"               /* delimiter between metadata name and value */
+#define TOK_DOT        "."               /* delimiter between metadata family and key */
+#define TOK_EDGE       "element.edge"    /* absorbption edge name */
+#define TOK_ELEM       "element.symbol"  /* atomic symbol of absorbing element */
+#define TOK_COLUMN     "column."         /* column label (followed by integer <= 64) */
+#define TOK_DSPACE     "mono.d_spacing"  /* mono d_spacing, in Angstroms */
 #define TOK_TIMESTAMP  "scan.start_time" /* scan time */
-#define TOK_USERCOM_0 "///"           /* start multi-line user comment */
-#define TOK_USERCOM_1 "---"           /* end multi-line user comment */
-#define TOK_COL_ENERGY "energy"       /* name of energy column */
-#define TOK_COL_ANGLE  "angle"        /* name of angle column */
-#define TOK_OUTER_VAL  "outer.value"  /* value for outer scan position */
-#define TOK_OUTER_NAME "outer.name"   /* name for outer scan position */
+#define TOK_TIMESTART  "scan.start_time" /* scan time */
+#define TOK_TIMEEND    "scan.end_time"   /* scan time */
+#define TOK_USERCOM_0  "///"             /* start multi-line user comment */
+#define TOK_USERCOM_1  "---"             /* end multi-line user comment */
+#define TOK_COL_ENERGY "energy"          /* name of energy column */
+#define TOK_COL_ANGLE  "angle"           /* name of angle column */
+#define TOK_OUTER_VAL  "outer.value"     /* value for outer scan position */
+#define TOK_OUTER_NAME "outer.name"      /* name for outer scan position */
 
 #define FAMILYNAME "^[ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz_][ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz_0123456789]+$"
 #define KEYNAME    "^[ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz_0123456789]+$"
@@ -100,11 +105,18 @@ static char *ValidElems[] =
   = 0  all OK.
   > 0  data file is valid but may be incomplete as XAFS data
 */
+#define REQ_ELEM              1
+#define REQ_EDGE              2
+#define REQ_DSPACING          4
+
 #define ERR_NOELEM            1
 #define ERR_NOEDGE            2
 #define ERR_NODSPACE          4
 #define ERR_NOMINUSLINE       8
 #define ERR_IGNOREDMETA      16
+#define ERR_REFELEM          32
+#define ERR_REFEDGE          64
+#define ERR_NOEXTRA         128
 
 #define ERR_NOTXDI           -1
 #define ERR_NOARR_NAME       -2

--- a/c/xdifile.h
+++ b/c/xdifile.h
@@ -1,8 +1,29 @@
+/* This file is free and unencumbered software released into the public domain. */
+/*                                                                              */
+/* Anyone is free to copy, modify, publish, use, compile, sell, or              */
+/* distribute this software, either in source code form or as a compiled        */
+/* binary, for any purpose, commercial or non-commercial, and by any            */
+/* means.                                                                       */
+/*                                                                              */
+/* In jurisdictions that recognize copyright laws, the author or authors        */
+/* of this software dedicate any and all copyright interest in the              */
+/* software to the public domain.                                               */
+/*                                                                              */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,              */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF           */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.       */
+/* IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR            */
+/* OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,        */
+/* ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR        */
+/* OTHER DEALINGS IN THE SOFTWARE.                                              */
+
 #if defined(WIN32) || defined(_WIN32) || defined(__WIN32__)
 #define _EXPORT(a) __declspec(dllexport) a _stdcall
 #else
 #define _EXPORT(a) a
 #endif
+
+#include <math.h>
 
 #define XDI_VERSION  "1.1.0"   /* XDI version marker */
 
@@ -68,7 +89,10 @@ _EXPORT(void) XDI_cleanup(XDIFile *xdifile, long err);
 #define FAMILYNAME "^[ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz_][ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz_0123456789]+$"
 #define KEYNAME    "^[ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz_0123456789]+$"
 
-#define DATALINE "^[ \t]*[0123456789.]"
+/* #define FAMILYNAME "(?i)^[a-z_][a-z0-9_]+$" */
+/* #define KEYNAME    "(?i)^[a-z0-9_]+$" */
+
+#define DATALINE "^([ \\t]*[0-9\\.])"
 
 /* Notes:
    1. The absorption edge must be one of those listed in ValidEdges below
@@ -100,34 +124,35 @@ static char *ValidElems[] =
    "Uut", "Fl", "Uup", "Lv", "Uus", "Uuo"};
 
 
-/* error codes   
-  < 0  data file is not valid
-  = 0  all OK.
-  > 0  data file is valid but may be incomplete as XAFS data
-*/
+/* errors in XDI_required_metadata */
 #define REQ_ELEM              1
 #define REQ_EDGE              2
-#define REQ_DSPACING          4
+#define REQ_NO_DSPACING       4
+#define REQ_INVALID_DSPACING  8
 
-#define ERR_NOELEM            1
-#define ERR_NOEDGE            2
-#define ERR_NODSPACE          4
-#define ERR_NOMINUSLINE       8
-#define ERR_IGNOREDMETA      16
-#define ERR_REFELEM          32
-#define ERR_REFEDGE          64
-#define ERR_NOEXTRA         128
+/* warnings from reading the XDI file */
+#define WRN_NODSPACE          1
+#define WRN_NOMINUSLINE       2
+#define WRN_IGNOREDMETA       4
+/* warnings from metadata value validation */
+#define WRN_NOELEM            8
+#define WRN_NOEDGE           16
+#define WRN_REFELEM          32
+#define WRN_REFEDGE          64
+#define WRN_NOEXTRA         128
+#define WRN_BAD_COL1        256
+#define WRN_DATE_FORMAT     512
+#define WRN_DATE_RANGE     1024
+#define WRN_BAD_DSPACING   2048
 
-#define ERR_NOTXDI           -1
-#define ERR_NOARR_NAME       -2
-#define ERR_NOARR_INDEX      -4
-#define ERR_META_FAMNAME     -8
-#define ERR_META_KEYNAME    -16
-#define ERR_META_FORMAT     -32
-#define ERR_DATE_FORMAT     -64
-#define ERR_DATE_RANGE     -128
-#define ERR_NCOLS_CHANGE   -256
-#define ERR_NONNUMERIC     -512
-#define ERR_MEMERROR      -1024
+/* errors reading the XDI file */
+#define ERR_NOTXDI           -1	/* used */
+#define ERR_META_FAMNAME     -2	/* used */
+#define ERR_META_KEYNAME     -4	/* used */
+#define ERR_META_FORMAT      -8	/* used */
+#define ERR_NCOLS_CHANGE    -16	/* used */
+#define ERR_NONNUMERIC      -32	/* used */
+#define ERR_MEMERROR        -64	/* NOT used */
 
-_EXPORT(char*) XDI_errorstring(int errcode);
+
+/* _EXPORT(char*) XDI_errorstring(int errcode); */

--- a/c/xdifile.h
+++ b/c/xdifile.h
@@ -58,12 +58,12 @@ typedef struct {
 
 } XDIFile;
 
-_EXPORT(int) XDI_readfile(char *filename, XDIFile *xdifile) ;
-_EXPORT(int) XDI_get_array_index(XDIFile *xdifile, long n, double *out);
-_EXPORT(int) XDI_get_array_name(XDIFile *xdifile, char *name, double *out);
-_EXPORT(int) XDI_required_metadata(XDIFile *xdifile);
-_EXPORT(int) XDI_defined_family(XDIFile *xdifile, char *family);
-_EXPORT(int) XDI_validate_item(XDIFile *xdifile, char *family, char *name, char *value);
+_EXPORT(int)  XDI_readfile(char *filename, XDIFile *xdifile) ;
+_EXPORT(int)  XDI_get_array_index(XDIFile *xdifile, long n, double *out);
+_EXPORT(int)  XDI_get_array_name(XDIFile *xdifile, char *name, double *out);
+_EXPORT(int)  XDI_required_metadata(XDIFile *xdifile);
+_EXPORT(int)  XDI_defined_family(XDIFile *xdifile, char *family);
+_EXPORT(int)  XDI_validate_item(XDIFile *xdifile, char *family, char *name, char *value);
 _EXPORT(void) XDI_cleanup(XDIFile *xdifile, long err);
 
 /* Tokens used in XDI File */

--- a/c/xdifile.h
+++ b/c/xdifile.h
@@ -144,6 +144,7 @@ static char *ValidElems[] =
 #define WRN_DATE_FORMAT     512
 #define WRN_DATE_RANGE     1024
 #define WRN_BAD_DSPACING   2048
+#define WRN_BAD_SAMPLE     4096
 
 /* errors reading the XDI file */
 #define ERR_NOTXDI           -1	/* used */

--- a/c/xdifile.h
+++ b/c/xdifile.h
@@ -155,5 +155,4 @@ static char *ValidElems[] =
 #define ERR_NONNUMERIC      -32	/* used */
 #define ERR_MEMERROR        -64	/* NOT used */
 
-
 /* _EXPORT(char*) XDI_errorstring(int errcode); */

--- a/data/cu_metal_10K.xdi
+++ b/data/cu_metal_10K.xdi
@@ -14,7 +14,7 @@
 # Element.symbol: Cu
 # Facility.energy: 2.584 GeV
 # Facility.name: NSLS
-# Facility.source: bend magnet
+# Facility.xray_source: bend magnet
 # Mono.d_spacing: 3.135301
 # Mono.name: Si(111)
 # Mono.stpdeg: 6400

--- a/perl/example/xdi_reader.pl
+++ b/perl/example/xdi_reader.pl
@@ -1,0 +1,60 @@
+#!/usr/bin/perl
+
+## This is a replica in perl of the xdi_reader.c test program
+## the only difference is the order in which the metadata is printed to the screen
+##
+## to run this *before* installing Xray::XDI, try
+##   perl -Iblib/lib -Iblib/arch example/xdi_reader.pl ../baddata/bad_32.xdi
+
+use strict;
+use warnings;
+use Xray::XDI;
+
+my $xdi = Xray::XDI->new(file=>$ARGV[0]||"");
+print  "Syntax: xdi_reader.pl filename\n",                                                                             exit if not defined($xdi->xdifile);
+printf "Error reading XDI file '%s':\n\t%s\t(error code = %d)\n",       $ARGV[0], $xdi->errormessage, $xdi->errorcode, exit if $xdi->errorcode < 0;
+printf "Warning reading XDI file '%s':\n\t%s\t(warning code = %d)\n\n", $ARGV[0], $xdi->errormessage, $xdi->errorcode       if $xdi->errorcode > 0;
+
+
+print  "#------\n";
+printf "# XDI FILE Read %s: |%s|%s|\n", $xdi->filename, $xdi->xdi_version, $xdi->extra_version;
+printf "# Elem/Edge: %s|%s|\n",         $xdi->element,  $xdi->edge;
+
+
+
+print  "# User comments:\n";
+print  $xdi->comments, $/;
+
+
+
+printf "# Metadata(%d entries):\n--\n", $xdi->nmetadata;
+foreach my $fam (sort keys %{$xdi->metadata}) {
+  foreach my $key (sort keys %{$xdi->metadata->{$fam}}) {
+    my $value = $xdi->metadata->{$fam}->{$key};
+    printf " %s / %s => %s\n", $fam, $key, $value;
+    my $i = $xdi->validate($fam, $key, $value);
+    if ($i) {
+      printf "-- Warning for %s.%s: %s\t(warning code = %d)\n\t%s\n",
+	$fam, $key, $value, $i, $xdi->errormessage;
+    };
+  };
+};
+print $/;
+
+
+
+my $i = $xdi->required;
+printf "# check for required metadata -- (requirement code %d):\n%s\n", $i, $xdi->errormessage;
+
+$i = $xdi->recommended;
+printf "# check for recommended metadata -- (recommendation code %d):\n%s\n", $i, $xdi->errormessage;
+
+
+
+printf "# Arrays Index, Name, Values: (%s points total):\n", $xdi->npts;
+$i = 0;
+foreach my $lab (@{$xdi->array_labels}) {
+  my @x = $xdi->get_array($lab);
+  printf "%d  %9s: %s, %s, %s, %s, ... %s, %s\n", $i, $lab, @x[0..3], @x[-2,-1];
+  ++$i;
+};

--- a/perl/lib/Xray/XDI.pm
+++ b/perl/lib/Xray/XDI.pm
@@ -19,7 +19,7 @@ has 'file' => (is => 'rw', isa => 'Str', traits => [qw(Clone)], default => q{},
 has 'xdifile' => (
 		  is        => 'ro',
 		  traits => [qw(NoClone)],
-		  isa       => 'Xray::XDIFile',
+		  #isa       => 'Xray::XDIFile'|'Undef',
 		  init_arg  => undef,
 		  lazy      => 1,
 		  builder   => '_build_object',
@@ -72,22 +72,32 @@ has 'data'           => (
 				      },
 			);
 
+sub DEMOLISH {
+  my ($self) = @_;
+  return if $self->errorcode;	# is this right?  or does the errorcode need to be passed to _cleanup?
+  return if not defined($self->xdifile);
+  $self->xdifile->_cleanup(0);
+};
+
 sub _build_object {
   my ($self) = @_;
   $self->error(q{});
   $self->ok(1);
   $self->warning(0);
   if (not -e $self->file) {
+    $self->errorcode(1);
     $self->error('The file '.$self->file.' does not exist as XDI');
     $self->ok(0);
     return undef;
   };
   if (not -r $self->file) {
+    $self->errorcode(1);
     $self->error('The file '.$self->file.' cannot be read as XDI');
     $self->ok(0);
     return undef;
   };
   if (-d $self->file) {
+    $self->errorcode(1);
     $self->error($self->file.' is a folder (i.e. not an XDI file)');
     $self->ok(0);
     return undef;

--- a/perl/lib/Xray/XDIFile.pm
+++ b/perl/lib/Xray/XDIFile.pm
@@ -148,13 +148,31 @@ SV* new(char* class, char* file, SV* errcode) {
   return obj_ref;
 }
 
+int _validate_item(SV* obj, char* family, char *name, char *value) {
+  int ret;
+  ret = XDI_validate_item((INT2PTR(XDIFile*, SvIV(SvRV(obj)))), family, name, value);
+  return ret;
+}
+
+int _required_metadata(SV* obj) {
+  int ret;
+  ret = XDI_required_metadata((INT2PTR(XDIFile*, SvIV(SvRV(obj)))));
+  return ret;
+}
+
+int _recommended_metadata(SV* obj) {
+  int ret;
+  ret = XDI_recommended_metadata((INT2PTR(XDIFile*, SvIV(SvRV(obj)))));
+  return ret;
+}
+
 void _cleanup(SV* obj, long err) {
   XDI_cleanup((INT2PTR(XDIFile*, SvIV(SvRV(obj)))), err);
 }
 
-char* _errorstring(SV* obj, int code) {
-  return XDI_errorstring(code);
-}
+/* char* _errorstring(SV* obj, int code) { */
+/*  return XDI_errorstring(code); */
+/* } */
 
 void _valid_edges(SV* obj) {
   long i;
@@ -240,6 +258,10 @@ double _dspacing(SV* obj) {
 
 char* _comments(SV* obj) {
        return (INT2PTR(XDIFile*, SvIV(SvRV(obj))))->comments;
+}
+
+char* _error_message(SV* obj) {
+       return (INT2PTR(XDIFile*, SvIV(SvRV(obj))))->error_message;
 }
 
 long _nmetadata(SV* obj) {

--- a/perl/t/00_base.t
+++ b/perl/t/00_base.t
@@ -47,6 +47,7 @@ ok($xdifile->_extra_version =~ m{GSE},         'extra_version');
 
 ok(ucfirst($xdifile->_element) eq 'Co',        'element');
 ok(ucfirst($xdifile->_edge) eq 'K',            'edge');
+print $xdifile->_dspacing, $/;
 ok(abs($xdifile->_dspacing - 3.13555) < $epsi, 'dspacing');
 ok($xdifile->_comments =~ m{room temperature}, 'comments');
 ok($xdifile->_nmetadata == 19,                 'nmetadata');

--- a/perl/t/01_moose_nonmoose.t
+++ b/perl/t/01_moose_nonmoose.t
@@ -17,8 +17,8 @@ my $here = dirname($0);
 my $file = File::Spec->catfile($here, '..', '..', 'data', 'co_metal_rt.xdi');
 my $xdi  = Xray::XDI->new(file=>$file);
 ok($xdi =~ m{Xray::XDI},                           'created Xray::XDI object');
-ok($xdi->ok,                                       'ok flag is true');
-ok($xdi->error eq '',                              'error text is empty');
+ok(($xdi->errorcode == 0),                         'errorcode 0');
+ok(($xdi->errormessage =~ m{\A\s*\z}),             'error text is empty');
 
 ok( $xdi->token('comment') eq '#',                 'token: comment');
 ok( $xdi->token('delimiter') eq ':',               'token: delimiter');

--- a/perl/t/02_moosish.t
+++ b/perl/t/02_moosish.t
@@ -17,7 +17,7 @@ my $here = dirname($0);
 my $file = File::Spec->catfile($here, '..', '..', 'data', 'co_metal_rt.xdi');
 my $xdi  = Xray::XDI->new(file=>$file);
 
-ok($xdi->ok,                                                      'file imported properly');
+ok($xdi->errorcode == 0,                                           'file imported properly');
 
 ##### test things that return arrays of strings #################
 

--- a/perl/t/03_nofile.t
+++ b/perl/t/03_nofile.t
@@ -14,9 +14,9 @@ BEGIN { use_ok('Xray::XDI') };
 my $here = dirname($0);
 my $file = File::Spec->catfile($here, '..', '..', 'data', 'co_metal_rt.xdiX');
 my $xdi  = Xray::XDI->new(file=>$file);
-ok($xdi->error =~ m{does not exist},                        'file not exist');
+ok($xdi->errormessage =~ m{does not exist},                        'file not exist');
 
 $file = File::Spec->catfile($here, '..', '..', 'data');
 $xdi  = Xray::XDI->new(file=>$file);
-ok($xdi->error =~ m{is a folder},                           'is a folder');
+ok($xdi->errormessage =~ m{is a folder},                           'is a folder');
 

--- a/perl/t/baddata/01_no_xdi_line.t
+++ b/perl/t/baddata/01_no_xdi_line.t
@@ -19,8 +19,8 @@ my $xdi  = Xray::XDI->new(file=>$file);
 #my $xdi  = Xray::XDI->new;
 #$xdi->file($file);
 
-ok((not $xdi->ok), 'bad_01.xdi flagged as failing to import');
-ok(($xdi->error =~ m{not an XDI}), 'correctly identified problem');
+ok(($xdi->errorcode<0), 'bad_01.xdi flagged as failing to import');
+ok(($xdi->errormessage =~ m{not an XDI}), 'correctly identified problem');
 
 open(my $COV, '>', 'coverage.txt');
 print $COV 1, $/;

--- a/perl/t/baddata/02_no_edge.t
+++ b/perl/t/baddata/02_no_edge.t
@@ -17,15 +17,17 @@ my $here = dirname($0);
 my $file = File::Spec->catfile($here, '..', '..', '..', 'baddata', 'bad_02.xdi');
 my $xdi  = Xray::XDI->new(file=>$file);
 
-ok(($xdi->warning and $xdi->ok), 'bad_02.xdi flagged with a warning');
-ok(($xdi->error =~ m{no element\.edge}), 'correctly identified missing edge symbol');
+$xdi->required;
+ok(($xdi->errorcode>0), 'bad_02.xdi flagged with a warning');
+ok(($xdi->errormessage =~ m{Element.edge missing}), 'correctly identified missing edge symbol');
 
 
 $file = File::Spec->catfile($here, '..', '..', '..', 'baddata', 'bad_04.xdi');
 $xdi  = Xray::XDI->new(file=>$file);
 
-ok(($xdi->warning and $xdi->ok), 'bad_04.xdi flagged with a warning');
-ok(($xdi->error =~ m{no element\.edge}), 'correctly identified invalid edge symbol');
+$xdi->required;
+ok(($xdi->errorcode>0), 'bad_04.xdi flagged with a warning');
+ok(($xdi->errormessage =~ m{Element.edge missing}), 'correctly identified invalid edge symbol');
 
 open(my $COV, '>>', 'coverage.txt');
 print $COV 2, $/;

--- a/perl/t/baddata/03_no_symbol.t
+++ b/perl/t/baddata/03_no_symbol.t
@@ -17,14 +17,16 @@ my $here = dirname($0);
 my $file = File::Spec->catfile($here, '..', '..', '..', 'baddata', 'bad_03.xdi');
 my $xdi  = Xray::XDI->new(file=>$file);
 
-ok(($xdi->warning and $xdi->ok), 'bad_03.xdi flagged with a warning');
-ok(($xdi->error =~ m{no element.symbol}), 'correctly identified missing element symbol');
+$xdi->required;
+ok(($xdi->errorcode>0), 'bad_03.xdi flagged with a warning');
+ok(($xdi->errormessage =~ m{Element.symbol missing}), 'correctly identified missing element symbol');
 
 $file = File::Spec->catfile($here, '..', '..', '..', 'baddata', 'bad_05.xdi');
 $xdi  = Xray::XDI->new(file=>$file);
 
-ok(($xdi->warning and $xdi->ok), 'bad_05.xdi flagged with a warning');
-ok(($xdi->error =~ m{no element.symbol}), 'correctly identified invalid element symbol');
+$xdi->required;
+ok(($xdi->errorcode>0), 'bad_05.xdi flagged with a warning');
+ok(($xdi->errormessage =~ m{Element.symbol missing}), 'correctly identified invalid element symbol');
 
 
 open(my $COV, '>>', 'coverage.txt');

--- a/perl/t/baddata/06_no_minus_signs.t
+++ b/perl/t/baddata/06_no_minus_signs.t
@@ -17,8 +17,8 @@ my $here = dirname($0);
 my $file = File::Spec->catfile($here, '..', '..', '..', 'baddata', 'bad_06.xdi');
 my $xdi  = Xray::XDI->new(file=>$file);
 
-ok(($xdi->warning and $xdi->ok), 'bad_06.xdi flagged with warning');
-ok(($xdi->error =~ m{no line of minus signs}), 'correctly identified lack of minus signs ');
+ok(($xdi->errorcode>0), 'bad_06.xdi flagged with warning');
+ok(($xdi->errormessage =~ m{no line of minus signs}), 'correctly identified lack of minus signs ');
 
 
 open(my $COV, '>>', 'coverage.txt');

--- a/perl/t/baddata/07_columns.t
+++ b/perl/t/baddata/07_columns.t
@@ -15,26 +15,30 @@ my $here = dirname($0);
 my $file = File::Spec->catfile($here, '..', '..', '..', 'baddata', 'bad_07.xdi');
 my $xdi  = Xray::XDI->new(file=>$file);
 
-ok(($xdi->ok), 'bad_07.xdi flagged as ok');
-ok((not $xdi->error), 'no column labels');
+$xdi->recommended;
+ok(($xdi->errorcode>1), 'bad_07.xdi flagged as ok');
+ok(($xdi->errormessage =~ m{Column.1}), 'no column labels');
 
 $file = File::Spec->catfile($here, '..', '..', '..', 'baddata', 'bad_08.xdi');
 $xdi  = Xray::XDI->new(file=>$file);
 
-ok(($xdi->ok), 'bad_08.xdi flagged as ok');
-ok((not $xdi->error), 'to few column labels');
+$xdi->recommended;
+ok(($xdi->errorcode == 0), 'bad_08.xdi flagged as ok');
+ok(($xdi->errormessage =~ m{\A\s*\z}), 'to few column labels');
 
 $file = File::Spec->catfile($here, '..', '..', '..', 'baddata', 'bad_09.xdi');
 $xdi  = Xray::XDI->new(file=>$file);
 
-ok(($xdi->ok), 'bad_09.xdi flagged as ok');
-ok((not $xdi->error), 'to many column labels');
+$xdi->recommended;
+ok(($xdi->errorcode == 0), 'bad_09.xdi flagged as ok');
+ok(($xdi->errormessage =~ m{\A\s*\z}), 'to many column labels');
 
 $file = File::Spec->catfile($here, '..', '..', '..', 'baddata', 'bad_10.xdi');
 $xdi  = Xray::XDI->new(file=>$file);
 
-ok(($xdi->ok), 'bad_10.xdi flagged as ok');
-ok((not $xdi->error), 'column indeces not continuous');
+$xdi->recommended;
+ok(($xdi->errorcode == 0), 'bad_10.xdi flagged as ok');
+ok(($xdi->errormessage =~ m{\A\s*\z}), 'column indeces not continuous');
 
 
 open(my $COV, '>>', 'coverage.txt');

--- a/perl/t/baddata/11_bad_comment_char.t
+++ b/perl/t/baddata/11_bad_comment_char.t
@@ -17,8 +17,8 @@ my $here = dirname($0);
 my $file = File::Spec->catfile($here, '..', '..', '..', 'baddata', 'bad_11.xdi');
 my $xdi  = Xray::XDI->new(file=>$file);
 
-ok(($xdi->warning and $xdi->ok), 'bad_11.xdi flagged as failing to import');
-ok(($xdi->error =~ m{contains unrecognized header lines}), 'correctly identified bad comment character in metadata line');
+ok(($xdi->errorcode>0), 'bad_11.xdi flagged with warning on import');
+ok(($xdi->errormessage =~ m{contains unrecognized header lines}), 'correctly identified bad comment character in metadata line');
 
 
 open(my $COV, '>>', 'coverage.txt');

--- a/perl/t/baddata/12_no_dspacing.t
+++ b/perl/t/baddata/12_no_dspacing.t
@@ -17,8 +17,8 @@ my $here = dirname($0);
 my $file = File::Spec->catfile($here, '..', '..', '..', 'baddata', 'bad_12.xdi');
 my $xdi  = Xray::XDI->new(file=>$file);
 
-ok(($xdi->warning and $xdi->ok), 'bad_12.xdi flagged as ok');
-ok(($xdi->error =~ m{no mono.d_spacing}), 'correctly identified missing d-spacing');
+ok(($xdi->errorcode>0), 'bad_12.xdi flagged as ok');
+ok(($xdi->errormessage =~ m{no mono.d_spacing}), 'correctly identified missing d-spacing');
 
 
 open(my $COV, '>>', 'coverage.txt');

--- a/perl/t/baddata/13_inconsistent_columns.t
+++ b/perl/t/baddata/13_inconsistent_columns.t
@@ -17,14 +17,14 @@ my $here = dirname($0);
 my $file = File::Spec->catfile($here, '..', '..', '..', 'baddata', 'bad_13.xdi');
 my $xdi  = Xray::XDI->new(file=>$file);
 
-ok((not $xdi->ok), 'bad_13.xdi flagged as failing to import');
-ok(($xdi->error =~ m{number of columns changes}), 'correctly identified too few columns');
+ok(($xdi->errorcode<0), 'bad_13.xdi flagged as failing to import');
+ok(($xdi->errormessage =~ m{number of columns changes}), 'correctly identified too few columns');
 
 $file = File::Spec->catfile($here, '..', '..', '..', 'baddata', 'bad_14.xdi');
 $xdi  = Xray::XDI->new(file=>$file);
 
-ok((not $xdi->ok), 'bad_14.xdi flagged as failing to import');
-ok(($xdi->error =~ m{number of columns changes}), 'correctly identified too many columns');
+ok(($xdi->errorcode<0), 'bad_14.xdi flagged as failing to import');
+ok(($xdi->errormessage =~ m{number of columns changes}), 'correctly identified too many columns');
 
 
 open(my $COV, '>>', 'coverage.txt');

--- a/perl/t/baddata/15_nonnumeric.t
+++ b/perl/t/baddata/15_nonnumeric.t
@@ -17,20 +17,20 @@ my $here = dirname($0);
 my $file = File::Spec->catfile($here, '..', '..', '..', 'baddata', 'bad_15.xdi');
 my $xdi  = Xray::XDI->new(file=>$file);
 
-ok((not $xdi->ok), 'bad_15.xdi flagged as failing to import');
-ok(($xdi->error =~ m{non-numeric value}), 'correctly identified NaN as a problem');
+ok(($xdi->errorcode<0), 'bad_15.xdi flagged as failing to import');
+ok(($xdi->errormessage =~ m{non-numeric value}), 'correctly identified NaN as a problem');
 
 $file = File::Spec->catfile($here, '..', '..', '..', 'baddata', 'bad_16.xdi');
 $xdi  = Xray::XDI->new(file=>$file);
 
-ok((not $xdi->ok), 'bad_16.xdi flagged as failing to import');
-ok(($xdi->error =~ m{non-numeric value}), 'correctly identified string as a problem');
+ok(($xdi->errorcode<0), 'bad_16.xdi flagged as failing to import');
+ok(($xdi->errormessage =~ m{non-numeric value}), 'correctly identified string as a problem');
 
 $file = File::Spec->catfile($here, '..', '..', '..', 'baddata', 'bad_17.xdi');
 $xdi  = Xray::XDI->new(file=>$file);
 
-ok((not $xdi->ok), 'bad_17.xdi flagged as failing to import');
-ok(($xdi->error =~ m{non-numeric value}), 'correctly identified 1.2.3 as a problem');
+ok(($xdi->errorcode<0), 'bad_17.xdi flagged as failing to import');
+ok(($xdi->errormessage =~ m{non-numeric value}), 'correctly identified 1.2.3 as a problem');
 
 
 open(my $COV, '>>', 'coverage.txt');

--- a/perl/t/baddata/18_headers.t
+++ b/perl/t/baddata/18_headers.t
@@ -2,7 +2,7 @@
 
 ## test the bad headers examples
 
-use Test::More tests => 15;
+use Test::More tests => 13;
 
 use strict;
 use warnings;
@@ -15,44 +15,45 @@ my $here = dirname($0);
 my $file = File::Spec->catfile($here, '..', '..', '..', 'baddata', 'bad_18.xdi');
 my $xdi  = Xray::XDI->new(file=>$file);
 
-ok((not $xdi->ok), 'bad_18.xdi flagged as failing to import');
-ok(($xdi->error =~ m{metadata not formatted as}), 'correctly identified Family.Key -- no value');
+ok(($xdi->errorcode<0), 'bad_18.xdi flagged as failing to import');
+ok(($xdi->errormessage =~ m{not formatted as}), 'correctly identified Family.Key -- no value');
 
 $file = File::Spec->catfile($here, '..', '..', '..', 'baddata', 'bad_19.xdi');
 $xdi  = Xray::XDI->new(file=>$file);
 
-ok((not $xdi->ok), 'bad_19.xdi flagged as failing to import');
-ok(($xdi->error =~ m{metadata not formatted as}), 'correctly identified Family.Key -- no colon');
+ok(($xdi->errorcode<0), 'bad_19.xdi flagged as failing to import');
+ok(($xdi->errormessage =~ m{not formatted as}), 'correctly identified Family.Key -- no colon');
 
 $file = File::Spec->catfile($here, '..', '..', '..', 'baddata', 'bad_20.xdi');
 $xdi  = Xray::XDI->new(file=>$file);
 
-ok((not $xdi->ok), 'bad_20.xdi flagged as failing to import');
-ok(($xdi->error =~ m{metadata not formatted as}), 'correctly identified Family.Key -- two colons');
+ok(($xdi->errorcode<0), 'bad_20.xdi flagged as failing to import');
+ok(($xdi->errormessage =~ m{not formatted as}), 'correctly identified Family.Key -- two colons');
 
 $file = File::Spec->catfile($here, '..', '..', '..', 'baddata', 'bad_21.xdi');
 $xdi  = Xray::XDI->new(file=>$file);
 
-ok((not $xdi->ok), 'bad_21.xdi flagged as failing to import');
-ok(($xdi->error =~ m{metadata not formatted as}), 'correctly identified Family.Key -- no dot');
+ok(($xdi->errorcode<0), 'bad_21.xdi flagged as failing to import');
+ok(($xdi->errormessage =~ m{not formatted as}), 'correctly identified Family.Key -- no dot');
 
 $file = File::Spec->catfile($here, '..', '..', '..', 'baddata', 'bad_22.xdi');
 $xdi  = Xray::XDI->new(file=>$file);
 
-ok((not $xdi->ok), 'bad_22.xdi flagged as failing to import');
-ok(($xdi->error =~ m{invalid keyword name}), 'correctly identified Family.Key -- two dots');
+ok(($xdi->errorcode<0), 'bad_22.xdi flagged as failing to import');
+ok(($xdi->errormessage =~ m{invalid keyword name}), 'correctly identified Family.Key -- two dots');
 
-$file = File::Spec->catfile($here, '..', '..', '..', 'baddata', 'bad_23.xdi');
-$xdi  = Xray::XDI->new(file=>$file);
+# $file = File::Spec->catfile($here, '..', '..', '..', 'baddata', 'bad_23.xdi');
+# $xdi  = Xray::XDI->new(file=>$file);
 
-ok(($xdi->ok), 'bad_23.xdi flagged as ok');
-ok((not $xdi->error), 'correctly identified Family.Key -- key starts with number');
+# ok(($xdi->errorcode==0), 'bad_23.xdi flagged as ok');
+# ok(($xdi->errormessage), 'correctly identified Family.Key -- key starts with number');
+
 
 $file = File::Spec->catfile($here, '..', '..', '..', 'baddata', 'bad_24.xdi');
 $xdi  = Xray::XDI->new(file=>$file);
 
-ok((not $xdi->ok), 'bad_24.xdi flagged as failing to import');
-ok(($xdi->error =~ m{invalid family name}), 'correctly identified Family.Key -- family starts with number');
+ok(($xdi->errorcode<0), 'bad_24.xdi flagged as failing to import');
+ok(($xdi->errormessage =~ m{invalid family name}), 'correctly identified Family.Key -- family starts with number');
 
 open(my $COV, '>>', 'coverage.txt');
 print $COV 18, $/;

--- a/perl/t/baddata/25_things_missing.t
+++ b/perl/t/baddata/25_things_missing.t
@@ -15,20 +15,21 @@ my $here = dirname($0);
 my $file = File::Spec->catfile($here, '..', '..', '..', 'baddata', 'bad_25.xdi');
 my $xdi  = Xray::XDI->new(file=>$file);
 
-ok(($xdi->ok), 'bad_25.xdi flagged as ok');
-ok((not $xdi->error), 'missing extra version');
+ok(($xdi->errorcode == 0), 'bad_25.xdi flagged as ok');
+$xdi->validate('GSE', 'EXTRA', $xdi->metadata->{GSE}->{EXTRA});
+ok(($xdi->errormessage =~ m{extension field used without}), 'missing extra version');
 
 $file = File::Spec->catfile($here, '..', '..', '..', 'baddata', 'bad_26.xdi');
 $xdi  = Xray::XDI->new(file=>$file);
 
-ok(($xdi->ok), 'bad_26.xdi flagged as ok');
-ok((not $xdi->error), 'missing user comments');
+ok(($xdi->errorcode==0), 'bad_26.xdi flagged as ok');
+ok(($xdi->comments =~ m{\A\s*\z}), 'missing user comments');
 
 $file = File::Spec->catfile($here, '..', '..', '..', 'baddata', 'bad_27.xdi');
 $xdi  = Xray::XDI->new(file=>$file);
 
-ok(($xdi->ok), 'bad_27.xdi flagged as ok');
-ok((not $xdi->error), 'line of slashes, no user comments');
+ok(($xdi->errorcode==0), 'bad_27.xdi flagged as ok');
+ok(($xdi->comments =~ m{\A\s*\z}), 'line of slashes, no user comments');
 
 open(my $COV, '>>', 'coverage.txt');
 print $COV 25, $/;

--- a/perl/t/baddata/28_datatime.t
+++ b/perl/t/baddata/28_datatime.t
@@ -15,14 +15,16 @@ my $here = dirname($0);
 my $file = File::Spec->catfile($here, '..', '..', '..', 'baddata', 'bad_28.xdi');
 my $xdi  = Xray::XDI->new(file=>$file);
 
-ok((not $xdi->ok), 'bad_28.xdi flagged as failing to import');
-ok(($xdi->error =~ m{invalid timestamp}), 'correctly identified invalid timestamp format');
+ok(($xdi->errorcode == 0), 'bad_28.xdi imports ok');
+$xdi->validate('Scan', 'start_time', $xdi->metadata->{Scan}->{start_time});
+ok(($xdi->errormessage =~ m{invalid timestamp}), 'correctly identified invalid timestamp format');
 
 $file = File::Spec->catfile($here, '..', '..', '..', 'baddata', 'bad_29.xdi');
 $xdi  = Xray::XDI->new(file=>$file);
 
-ok((not $xdi->ok), 'bad_29.xdi flagged as failing to import');
-ok(($xdi->error =~ m{invalid timestamp}), 'correctly identified invalid timestamp month range');
+ok(($xdi->errorcode == 0), 'bad_29.xdi imports ok');
+$xdi->validate('Scan', 'start_time', $xdi->metadata->{Scan}->{start_time});
+ok(($xdi->errormessage =~ m{invalid timestamp}), 'correctly identified invalid timestamp month range');
 
 open(my $COV, '>>', 'coverage.txt');
 print $COV 28, $/;

--- a/perl/t/gooddata/01_cu_metal_10k.t
+++ b/perl/t/gooddata/01_cu_metal_10k.t
@@ -41,7 +41,7 @@ ok( (($keywords[0] eq 'collimation')          and
 
 ##### test get_item #############################################
 ok($xdi->get_item(qw(Mono name)) eq 'Si(111)',                     'get_item: fetching Mono.name');
-ok($xdi->get_item(qw(Facility source)) eq 'bend magnet',           'get_item: fetching Facility.xray_source');
+ok($xdi->get_item(qw(Facility xray_source)) eq 'bend magnet',           'get_item: fetching Facility.xray_source');
 
 ##### test get_array and get_iarray ##############################
 my @values = (.8856322E+04, .9656931E+00);

--- a/perl/t/gooddata/01_cu_metal_10k.t
+++ b/perl/t/gooddata/01_cu_metal_10k.t
@@ -17,7 +17,7 @@ my $here = dirname($0);
 my $file = File::Spec->catfile($here, '..', '..', '..', 'data', 'cu_metal_10K.xdi');
 my $xdi  = Xray::XDI->new(file=>$file);
 
-ok($xdi->ok,                                                      'file imported properly');
+ok($xdi->errorcode == 0,                                          'file imported properly');
 
 ##### test things that return arrays of strings #################
 

--- a/perl/t/gooddata/02_cu_metal_rt.t
+++ b/perl/t/gooddata/02_cu_metal_rt.t
@@ -17,7 +17,7 @@ my $here = dirname($0);
 my $file = File::Spec->catfile($here, '..', '..', '..', 'data', 'cu_metal_rt.xdi');
 my $xdi  = Xray::XDI->new(file=>$file);
 
-ok($xdi->ok,                                                      'file imported properly');
+ok($xdi->errorcode == 0,                                          'file imported properly');
 
 ##### test things that return arrays of strings #################
 

--- a/perl/t/gooddata/03_fe2o3.t
+++ b/perl/t/gooddata/03_fe2o3.t
@@ -17,7 +17,7 @@ my $here = dirname($0);
 my $file = File::Spec->catfile($here, '..', '..', '..', 'data', 'fe2o3_rt.xdi');
 my $xdi  = Xray::XDI->new(file=>$file);
 
-ok($xdi->ok,                                                      'file imported properly');
+ok($xdi->errorcode == 0,                                          'file imported properly');
 
 ##### test things that return arrays of strings #################
 

--- a/perl/t/gooddata/04_fe3c_rt.t
+++ b/perl/t/gooddata/04_fe3c_rt.t
@@ -17,7 +17,7 @@ my $here = dirname($0);
 my $file = File::Spec->catfile($here, '..', '..', '..', 'data', 'fe3c_rt.xdi');
 my $xdi  = Xray::XDI->new(file=>$file);
 
-ok($xdi->ok,                                                      'file imported properly');
+ok($xdi->errorcode == 0,                                          'file imported properly');
 
 ##### test things that return arrays of strings #################
 

--- a/perl/t/gooddata/05_fe_metal_rt.t
+++ b/perl/t/gooddata/05_fe_metal_rt.t
@@ -17,7 +17,7 @@ my $here = dirname($0);
 my $file = File::Spec->catfile($here, '..', '..', '..', 'data', 'fe_metal_rt.xdi');
 my $xdi  = Xray::XDI->new(file=>$file);
 
-ok($xdi->ok,                                                      'file imported properly');
+ok($xdi->errorcode == 0,                                          'file imported properly');
 
 ##### test things that return arrays of strings #################
 

--- a/perl/t/gooddata/06_fen_rt.t
+++ b/perl/t/gooddata/06_fen_rt.t
@@ -17,7 +17,7 @@ my $here = dirname($0);
 my $file = File::Spec->catfile($here, '..', '..', '..', 'data', 'fen_rt.xdi');
 my $xdi  = Xray::XDI->new(file=>$file);
 
-ok($xdi->ok,                                                      'file imported properly');
+ok($xdi->errorcode == 0,                                          'file imported properly');
 
 ##### test things that return arrays of strings #################
 

--- a/perl/t/gooddata/07_feo_rt1.t
+++ b/perl/t/gooddata/07_feo_rt1.t
@@ -17,7 +17,7 @@ BEGIN { use_ok('Xray::XDI') };
 my $here = dirname($0);
 my $file = File::Spec->catfile($here, '..', '..', '..', 'data', 'feo_rt1.xdi');
 my $xdi  = Xray::XDI->new(file=>$file);
-ok($xdi->ok,                                                      'file imported properly');
+ok($xdi->errorcode == 0,                                          'file imported properly');
 
 
 ##### test things that return arrays of strings #################

--- a/perl/t/gooddata/08_ni_metal_rt.t
+++ b/perl/t/gooddata/08_ni_metal_rt.t
@@ -17,7 +17,7 @@ my $here = dirname($0);
 my $file = File::Spec->catfile($here, '..', '..', '..', 'data', 'ni_metal_rt.xdi');
 my $xdi  = Xray::XDI->new(file=>$file);
 
-ok($xdi->ok,                                                      'file imported properly');
+ok($xdi->errorcode == 0,                                          'file imported properly');
 
 ##### test things that return arrays of strings #################
 

--- a/perl/t/gooddata/09_pt_metal_rt.t
+++ b/perl/t/gooddata/09_pt_metal_rt.t
@@ -17,7 +17,7 @@ my $here = dirname($0);
 my $file = File::Spec->catfile($here, '..', '..', '..', 'data', 'pt_metal_rt.xdi');
 my $xdi  = Xray::XDI->new(file=>$file);
 
-ok($xdi->ok,                                                      'file imported properly');
+ok($xdi->errorcode == 0,                                          'file imported properly');
 
 ##### test things that return arrays of strings #################
 

--- a/perl/t/gooddata/10_se_na2so4_rt.t
+++ b/perl/t/gooddata/10_se_na2so4_rt.t
@@ -17,7 +17,7 @@ my $here = dirname($0);
 my $file = File::Spec->catfile($here, '..', '..', '..', 'data', 'se_na2so4_rt.xdi');
 my $xdi  = Xray::XDI->new(file=>$file);
 
-ok($xdi->ok,                                                      'file imported properly');
+ok($xdi->errorcode == 0,                                          'file imported properly');
 
 ##### test things that return arrays of strings #################
 

--- a/perl/t/gooddata/11_se_znse_rt.t
+++ b/perl/t/gooddata/11_se_znse_rt.t
@@ -17,7 +17,7 @@ my $here = dirname($0);
 my $file = File::Spec->catfile($here, '..', '..', '..', 'data', 'se_znse_rt.xdi');
 my $xdi  = Xray::XDI->new(file=>$file);
 
-ok($xdi->ok,                                                      'file imported properly');
+ok($xdi->errorcode == 0,                                          'file imported properly');
 
 ##### test things that return arrays of strings #################
 

--- a/perl/t/gooddata/12_zn_na2so4_rt.t
+++ b/perl/t/gooddata/12_zn_na2so4_rt.t
@@ -17,7 +17,7 @@ my $here = dirname($0);
 my $file = File::Spec->catfile($here, '..', '..', '..', 'data', 'zn_znse_rt.xdi');
 my $xdi  = Xray::XDI->new(file=>$file);
 
-ok($xdi->ok,                                                      'file imported properly');
+ok($xdi->errorcode == 0,                                          'file imported properly');
 
 ##### test things that return arrays of strings #################
 

--- a/specification/dictionary.md
+++ b/specification/dictionary.md
@@ -207,16 +207,16 @@ The tag **must** be interpreted as case insentitive.
 ## Required metadata
 
 Three items are essential to the interchange and successful
-interpretation of XAS data. These are **required** in all files using
-the [XDI specification](spec.md).
+interpretation of XAS data. These are **required** for a file to be a
+compliant XDI file.
 
  * `Element.symbol`: The element of the absorbing atom. The periodic
    table is replete with examples of atoms that have absorption edges
    with very similar edge energies.  For example, the tabulated values
-   of the Cr K edge and the Ba L1 edge are both 5989 eV.  Without
-   identification of the species of the absorbing atom and of the
-   absorption edge measured, some data cannot cannot be unambiguously
-   identified.
+   of the Cr K edge and the Ba L1 edge are both 5989 eV, while Se K
+   and Tl L3 are both at 12658.  Without identification of the species
+   of the absorbing atom and of the absorption edge measured, some
+   data cannot cannot be unambiguously identified.
 
  * `Element.edge`: The absorption edge measured.  See above.
 
@@ -254,7 +254,7 @@ value to the interpretation of the data.
      * _Units_: mA, A
      * _Format_: float + units
 
-* **Namespace:** `Facility` -- **Tag:** `source`
+* **Namespace:** `Facility` -- **Tag:** `xray_source`
      * _Description_: A string identifying the source of the X-rays,
        such as "bend magnet", "undulator", or "rotating copper
        anode". This is **recommended** for use in all XDI files.


### PR DESCRIPTION
This PR implements what I think is a more sane way of managing the validation of XDI data and metadata.  The API is explained in full in the `c/README.md` file, but I'll give an overview here.

1. `XDI_readfile` will flag an error if the XDI file cannot be read at all (i.e. non-numbers in the data table, missing version info in line 1, and a few others).
1. `XDI_readfile` will flag a warning for a small number of situations, but carry on anyway.
1. The `XDI_required_metadata` checks that `Mono.d_spacing`, `Element.symbol`, and `Element.edge` are present and interpretable.  It returns 0 if all is OK, it returns a positive number if the metadata are not compliant.
1. The `XDI_recommended_metadata` method checks for several things that I called out in the dictionary as being specifically recommended.  I am open to modifying this list or even dropping this method altogether, but I think it is a good idea to set a baseline of data file quality.
1. `XDI_validate_item` check a metadata item against its definition.  For most items in the dictionary, this returns 0 without doing anything.  Several items in the dictionary have clear definitions (`Scan.start_time` for example) and will be checked by this method.  My hope is that by abstracting out this validation step, it will be easy to respond to changes in the dictionary.

The current state of the `libxdifile` and `xdi_reader` passes running on all of `data` and `baddata` without any issues raised by Valgrind.

This PR also upgrades to the latest version of SLRE.  That's a quirky piece of software....

I added licensing information to the repo, attaching a public domain statement to the .c and .h files.  Public domain seems appropriate for this application.

This PR also adds a few more `baddata` files and makes a lot of changes to the perl wrapper.

I'll wait a few days before merging this PR.
