### PR TITLE
Header cleanups

### DIFF
--- a/c/Makefile.in
+++ b/c/Makefile.in
@@ -38,7 +38,7 @@ LINKXDIF = -L$(libdir) -L. -lxdifile
 
 all: $(READER) $(LIBXDIF_STATIC) $(LIBXDIF_SHARED)
 
-$(READER).o: $(READER).c
+$(READER).o: $(READER).c $(XDIHEADERS)
 
 .PHONY: clean install default
 

--- a/c/xdifile.h
+++ b/c/xdifile.h
@@ -62,8 +62,15 @@ _EXPORT(int)  XDI_readfile(char *filename, XDIFile *xdifile) ;
 _EXPORT(int)  XDI_get_array_index(XDIFile *xdifile, long n, double *out);
 _EXPORT(int)  XDI_get_array_name(XDIFile *xdifile, char *name, double *out);
 _EXPORT(int)  XDI_required_metadata(XDIFile *xdifile);
+_EXPORT(int)  XDI_recommended_metadata(XDIFile *xdifile);
 _EXPORT(int)  XDI_defined_family(XDIFile *xdifile, char *family);
 _EXPORT(int)  XDI_validate_item(XDIFile *xdifile, char *family, char *name, char *value);
+_EXPORT(int)  XDI_validate_mono(XDIFile *xdifile, char *name, char *value);
+_EXPORT(int)  XDI_validate_sample(XDIFile *xdifile, char *name, char *value);
+_EXPORT(int)  XDI_validate_scan(XDIFile *xdifile, char *name, char *value);
+_EXPORT(int)  XDI_validate_column(XDIFile *xdifile, char *name, char *value);
+_EXPORT(int)  XDI_validate_element(XDIFile *xdifile, char *name, char *value);
+
 _EXPORT(void) XDI_cleanup(XDIFile *xdifile, long err);
 
 /* Tokens used in XDI File */


### PR DESCRIPTION
this add declarations to xdifile.h for the XDI_validate_****() and so on to quiet compiler warnings.  it also makes the dependence of xdi_reader.o on the header files explicit in the Makefile.in