### PR TITLE
bugfix (Windows) XDI_validate_** NOT exported

### DIFF
--- a/c/xdifile.h
+++ b/c/xdifile.h
@@ -65,11 +65,11 @@ _EXPORT(int)  XDI_required_metadata(XDIFile *xdifile);
 _EXPORT(int)  XDI_recommended_metadata(XDIFile *xdifile);
 _EXPORT(int)  XDI_defined_family(XDIFile *xdifile, char *family);
 _EXPORT(int)  XDI_validate_item(XDIFile *xdifile, char *family, char *name, char *value);
-_EXPORT(int)  XDI_validate_mono(XDIFile *xdifile, char *name, char *value);
-_EXPORT(int)  XDI_validate_sample(XDIFile *xdifile, char *name, char *value);
-_EXPORT(int)  XDI_validate_scan(XDIFile *xdifile, char *name, char *value);
-_EXPORT(int)  XDI_validate_column(XDIFile *xdifile, char *name, char *value);
-_EXPORT(int)  XDI_validate_element(XDIFile *xdifile, char *name, char *value);
+int XDI_validate_mono(XDIFile *xdifile, char *name, char *value);
+int XDI_validate_sample(XDIFile *xdifile, char *name, char *value);
+int XDI_validate_scan(XDIFile *xdifile, char *name, char *value);
+int XDI_validate_column(XDIFile *xdifile, char *name, char *value);
+int XDI_validate_element(XDIFile *xdifile, char *name, char *value);
 
 _EXPORT(void) XDI_cleanup(XDIFile *xdifile, long err);
 


### PR DESCRIPTION
I recently (d2638b77)  added _EXPORT(int) XDI_validate_*** in xdifile.h,   

The signatures in xdifile.c are simply int XDI_validate_***,  which causes Windows builds to fail.
Not all the XDI_validate_***  should be exported.  Having only XDI_validate_item() exported as part of the official API makes sense - the rest are implementation details.

This PR changes the header to actually match the C code, and the Windows DLL builds (and works!).