### PR TITLE
Warning codes

### DIFF
--- a/c/README.md
+++ b/c/README.md
@@ -289,24 +289,31 @@ translation of a table of error messages into another language.
 
 Here `<word>` will be the text that triggered the error.
 
-### XDI_readfile and XDI_validate_item warning codes
+### XDI_readfile warning codes
 
 |  code | message                                                      |
 | ----: | ------------------------------------------------------------ |
 |    1  | no mono.d_spacing given with angle array                     |
 |    2  | no line of minus signs '#-----' separating header from data  |
 |    4  | contains unrecognized header lines                           |
-|    8  | element.symbol missing or not valid                          |
-|   16  | element.edge missing or not valid                            |
-|   32  | element.reference not valid                                  |
-|   64  | element.ref\_edge  not valid                                 |
-|  128  | extension field used without versioning information          |
-|  256  | Column.1 is not "energy" or "angle"                          |
-|  512  | invalid timestamp: format should be ISO 8601 (YYYY-MM-DD HH:MM:SS) |
-| 1024  | invalid timestamp: date out of valid range                   |
-| 2048  | <not used>                                                   |
-| 4096  | bad value in Sample namespace                                |
-| 8192  | bad value in Facility namespace                              |
+
+
+### XDI_validate_item warning codes
+
+
+|  code | message                                                      |
+| ----: | ------------------------------------------------------------ |
+|  100  | element.symbol missing or not valid                          |
+|  101  | element.edge missing or not valid                            |
+|  102  | element.reference not valid                                  |
+|  103  | element.ref\_edge  not valid                                 |
+|  104  | extension field used without versioning information          |
+|  105  | Column.1 is not "energy" or "angle"                          |
+|  106  | invalid timestamp: format should be ISO 8601 (YYYY-MM-DD HH:MM:SS) |
+|  107  | invalid timestamp: date out of valid range                   |
+|  108  | <not used>                                                   |
+|  109  | bad value in Sample namespace                                |
+|  110  | bad value in Facility namespace                              |
 
 
 ### XDI_required_metadata return codes

--- a/c/xdifile.c
+++ b/c/xdifile.c
@@ -767,7 +767,7 @@ XDI_validate_item(XDIFile *xdifile, char *family, char *name, char *value) {
 
 
 /***************************************************************************/
-/* all tests in the Facility familty should return WRN_BAD_FACILITY if the */
+/* all tests in the Facility family should return WRN_BAD_FACILITY if the  */
 /* value does not match the definition.  error_message should explain	   */
 /* the problem in a way that is appropruiate to the metadata item	   */
 /***************************************************************************/
@@ -821,7 +821,7 @@ int XDI_validate_mono(XDIFile *xdifile, char *name, char *value) {
 }
 
 /***********************************************************************/
-/* all tests in the Sample familty should return WRN_BAD_SAMPLE if the */
+/* all tests in the Sample family should return WRN_BAD_SAMPLE if the  */
 /* value does not match the definition.  error_message should explain  */
 /* the problem in a way that is appropruiate to the metadata item      */
 /***********************************************************************/
@@ -849,11 +849,12 @@ int XDI_validate_sample(XDIFile *xdifile, char *name, char *value) {
 }
 
 
+/**************************************************************/
+/* tests if input string is a valid datetime timestamp.	      */
+/* This uses regular expression to check format and validates */
+/* range of values, though not exhaustively.		      */
+/**************************************************************/
 int xdi_is_datestring(char *inp) {
-  /* tests if input string is a valid datetime timestamp.
-     This uses regular expression to check format and validates
-     range of values, though not exhaustively.
-  */
   int regex_status;
   struct slre_cap caps[6];
   int year, month, day, hour, minute, sec;

--- a/c/xdifile.h
+++ b/c/xdifile.h
@@ -142,18 +142,18 @@ static char *ValidElems[] =
 #define WRN_NODSPACE          1
 #define WRN_NOMINUSLINE       2
 #define WRN_IGNOREDMETA       4
-/* warnings from metadata value validation */
-#define WRN_NOELEM            8
-#define WRN_NOEDGE           16
-#define WRN_REFELEM          32
-#define WRN_REFEDGE          64
-#define WRN_NOEXTRA         128
-#define WRN_BAD_COL1        256
-#define WRN_DATE_FORMAT     512
-#define WRN_DATE_RANGE     1024
-#define WRN_BAD_DSPACING   2048
-#define WRN_BAD_SAMPLE     4096
-#define WRN_BAD_FACILITY   8192
+/* warnings from metadata value validation, these are not use bitwise */
+#define WRN_NOELEM          100
+#define WRN_NOEDGE          101
+#define WRN_REFELEM         102
+#define WRN_REFEDGE         103
+#define WRN_NOEXTRA         104
+#define WRN_BAD_COL1        105
+#define WRN_DATE_FORMAT     106
+#define WRN_DATE_RANGE      107
+#define WRN_BAD_DSPACING    108
+#define WRN_BAD_SAMPLE      109
+#define WRN_BAD_FACILITY    110
 
 /* errors reading the XDI file */
 #define ERR_NOTXDI           -1	/* used */
@@ -167,6 +167,13 @@ static char *ValidElems[] =
 /* _EXPORT(char*) XDI_errorstring(int errcode); */
 
 
+/* List of required metadata items */
+static char *RequiredMetadata[] =
+  {                             /* these are the bits of the errorcode returned by XDI_recommended_metadata */
+    "Element.symbol",		/* 2^0 */
+    "Element.edge",     	/* 2^1 */
+    "Mono.d_spacing",		/* 2^2 */
+  };
 /* List of recommended metadata items */
 static char *RecommendedMetadata[] =
   {                             /* these are the bits of the errorcode returned by XDI_recommended_metadata */

--- a/languages/perl/example/xdi_reader.pl
+++ b/languages/perl/example/xdi_reader.pl
@@ -11,9 +11,17 @@ use warnings;
 use Xray::XDI;
 
 my $xdi = Xray::XDI->new(file=>$ARGV[0]||"");
-print  "Syntax: xdi_reader.pl filename\n",                                                                             exit if not defined($xdi->xdifile);
-printf "Error reading XDI file '%s':\n\t%s\t(error code = %d)\n",       $ARGV[0], $xdi->errormessage, $xdi->errorcode, exit if $xdi->errorcode < 0;
-printf "Warning reading XDI file '%s':\n\t%s\t(warning code = %d)\n\n", $ARGV[0], $xdi->errormessage, $xdi->errorcode       if $xdi->errorcode > 0;
+if (not defined($xdi->xdifile)) {
+  print  "Syntax: xdi_reader.pl filename\n";
+  exit;
+};
+if ($xdi->errorcode < 0) {
+  printf "Error reading XDI file '%s':\n\t%s\t(error code = %d)\n",       $ARGV[0], $xdi->errormessage, $xdi->errorcode;
+  exit;
+};
+if ($xdi->errorcode > 0) {
+  printf "Warning reading XDI file '%s':\n\t%s\t(warning code = %d)\n\n", $ARGV[0], $xdi->errormessage, $xdi->errorcode;
+};
 
 
 print  "#------\n";

--- a/languages/perl/lib/Xray/XDI.pm
+++ b/languages/perl/lib/Xray/XDI.pm
@@ -274,12 +274,20 @@ sub required {
   $self->errormessage($self->xdifile->_error_message);
   return $i;
 };
+sub required_list {
+  my ($self) = @_;
+  return Xray::XDIFile->_required_list;
+};
 sub recommended {
   my ($self) = @_;
   my $i = $self->xdifile->_recommended_metadata;
   $self->errorcode($i);
   $self->errormessage($self->xdifile->_error_message);
   return $i;
+};
+sub recommended_list {
+  my ($self) = @_;
+  return Xray::XDIFile->_recommended_list;
 };
 
 sub validate {

--- a/languages/perl/lib/Xray/XDIFile.pm
+++ b/languages/perl/lib/Xray/XDIFile.pm
@@ -160,10 +160,30 @@ int _required_metadata(SV* obj) {
   return ret;
 }
 
+void _required_list(SV* obj) {
+  long i;
+  Inline_Stack_Vars;
+  Inline_Stack_Reset;
+  for (i=0; i < sizeof(RequiredMetadata)/sizeof(RequiredMetadata[0]); i++) {
+    Inline_Stack_Push(sv_2mortal(newSVpv( RequiredMetadata[i], 0 )));
+  }
+  Inline_Stack_Done;
+}
+
 int _recommended_metadata(SV* obj) {
   int ret;
   ret = XDI_recommended_metadata((INT2PTR(XDIFile*, SvIV(SvRV(obj)))));
   return ret;
+}
+
+void _recommended_list(SV* obj) {
+  long i;
+  Inline_Stack_Vars;
+  Inline_Stack_Reset;
+  for (i=0; i < sizeof(RecommendedMetadata)/sizeof(RecommendedMetadata[0]); i++) {
+    Inline_Stack_Push(sv_2mortal(newSVpv( RecommendedMetadata[i], 0 )));
+  }
+  Inline_Stack_Done;
 }
 
 void _cleanup(SV* obj, long err) {


### PR DESCRIPTION
Numeric codes returned from `XDI_validate_item` used to be 1,2,4,8,etc -- that is, intended to be interpreted bitwise.  That method is now intended to be called on a single metadata item at a time, so bitwise warning codes don't make sense.  The warning codes are now incremented integers starting at 100.

This PR also includes a few small changes to the perl wrapper.
